### PR TITLE
Fix a few more typos

### DIFF
--- a/examples/macro/calculator/src/ui.rs
+++ b/examples/macro/calculator/src/ui.rs
@@ -2,14 +2,14 @@ use eframe::egui::{self, Button, Label, Response, RichText, Style, Visuals, Widg
 use eframe::egui::{Layout, Ui};
 use eframe::emath::Align;
 use eframe::epaint::{FontFamily, FontId};
-use statig::InitializedStatemachine;
+use statig::InitializedStateMachine;
 
 use crate::state::{Calculator, Event, Operator};
 
-pub struct App(pub InitializedStatemachine<Calculator>);
+pub struct App(pub InitializedStateMachine<Calculator>);
 
 impl std::ops::Deref for App {
-    type Target = InitializedStatemachine<Calculator>;
+    type Target = InitializedStateMachine<Calculator>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/examples/no_macro/calculator/src/ui.rs
+++ b/examples/no_macro/calculator/src/ui.rs
@@ -2,14 +2,14 @@ use eframe::egui::{self, Button, Label, Response, RichText, Style, Visuals, Widg
 use eframe::egui::{Layout, Ui};
 use eframe::emath::Align;
 use eframe::epaint::{FontFamily, FontId};
-use statig::InitializedStatemachine;
+use statig::InitializedStateMachine;
 
 use crate::state::{Calculator, Event, Operator};
 
-pub struct App(pub InitializedStatemachine<Calculator>);
+pub struct App(pub InitializedStateMachine<Calculator>);
 
 impl std::ops::Deref for App {
-    type Target = InitializedStatemachine<Calculator>;
+    type Target = InitializedStateMachine<Calculator>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! **Features**
 //!
-//! - Hierachical state machines
+//! - Hierarchical state machines
 //! - State-local storage
 //! - Compatible with `#![no_std]`, state machines are defined in ROM and no heap memory allocations.
 //! - (Optional) macro's for reducing boilerplate.
@@ -335,7 +335,7 @@
 //! points during state machine execution.
 //!
 //! - `on_dispatch` is called before an event is dispatched to a specific state or superstate.
-//! - `on_transition` is called after a transition has occured.
+//! - `on_transition` is called after a transition has occurred.
 //!
 //! ```
 //! # use statig::prelude::*;
@@ -373,9 +373,9 @@
 //!
 //! ## Implementation
 //!
-//! A lot of the implemenation details are dealt with by the `#[state_machine]` macro, but it's always valuable to understand what's happening behind the scenes. Furthermore, you'll see that the generated code is actually pretty straight-forward and could easily be written by hand, so if you prefer to avoid using macro's this is totally feasible.
+//! A lot of the implementation details are dealt with by the `#[state_machine]` macro, but it's always valuable to understand what's happening behind the scenes. Furthermore, you'll see that the generated code is actually pretty straight-forward and could easily be written by hand, so if you prefer to avoid using macro's this is totally feasible.
 //!
-//! The goal of `statig` is to represent a hierarchical state machine. Conceptually a hierarchical state machine can be tought of as tree.
+//! The goal of `statig` is to represent a hierarchical state machine. Conceptually a hierarchical state machine can be thought of as tree.
 //!
 //! ```text
 //!                           ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐             
@@ -509,7 +509,7 @@
 //! }
 //! ```
 //!
-//! When an event arrives, `statig` will first dispatch it to the current leaf state. If this state returns a `Super` response, it will then be dispatched to that state's superstate, which in turn returns its own response. Every time an event is defered to a superstate, `statig` will traverse upwards in the graph until it reaches the `Top` state. This is an implicit superstate that will consider every event as handled.
+//! When an event arrives, `statig` will first dispatch it to the current leaf state. If this state returns a `Super` response, it will then be dispatched to that state's superstate, which in turn returns its own response. Every time an event is deferred to a superstate, `statig` will traverse upwards in the graph until it reaches the `Top` state. This is an implicit superstate that will consider every event as handled.
 //!
 //! In case the returned response is a `Transition`, `statig` will perform a transition sequence by traversing the graph from the current source state to the target state by taking the shortest possible path. When this path is going upwards from the source state, every state that is passed will have its **exit action** executed. And then similarly when going downward, every state that is passed will have its **entry action** executed.
 //!
@@ -528,7 +528,7 @@
 //!
 //! Entry and exit actions also have access to state-local storage, but note that exit actions operate on state-local storage of the source state and that entry actions operate on the state-local storage of the target state.
 //!
-//! For example chaning the value of `counter` in the exit action of `LedOn` will have no effect on the value of `counter` in the `LedOff` state.
+//! For example chaining the value of `counter` in the exit action of `LedOn` will have no effect on the value of `counter` in the `LedOff` state.
 //!
 //! Finally, the `StateMachine` trait is implemented on the type that will be used for the shared storage.
 //!
@@ -711,7 +711,7 @@ pub use statig_macro::state;
 ///   the enum variant. It is crucial to understand that superstates never own
 ///   their data. Instead it is always borrowed from the underlying state or
 ///   superstate. This means the fields should be references with an
-///   assoaciated lifetime `'a`.
+///   associated lifetime `'a`.
 ///
 ///   <br/>
 #[cfg(feature = "macro")]

--- a/statig/src/state_machine.rs
+++ b/statig/src/state_machine.rs
@@ -66,7 +66,7 @@ impl<M> UninitializedStateMachine<M>
 where
     M: StateMachine,
 {
-    /// Initialize the state machine by excecuting all entry actions towards
+    /// Initialize the state machine by executing all entry actions towards
     /// the initial state.
     ///
     /// ```
@@ -139,7 +139,7 @@ where
         }
     }
 
-    /// Initialize the state machine by excecuting all entry actions towards the initial state.
+    /// Initialize the state machine by executing all entry actions towards the initial state.
     fn init(&mut self) {
         let enter_levels = self.state.depth();
         self.state.enter(&mut self.shared_storage, enter_levels);

--- a/statig/src/state_machine.rs
+++ b/statig/src/state_machine.rs
@@ -35,12 +35,12 @@ where
 
 /// A state machine where the shared storage is of type `Self`.
 pub trait StateMachineSharedStorage: StateMachine {
-    /// Create an uninitialized state machine. Use [UninitializedStateMachine::init] to initialize it.
-    fn state_machine(self) -> UninitializedStateMachine<Self>
+    /// Create an uninitialized state machine. Use [UnInitializedStateMachine::init] to initialize it.
+    fn state_machine(self) -> UnInitializedStateMachine<Self>
     where
         Self: Sized,
     {
-        UninitializedStateMachine {
+        UnInitializedStateMachine {
             shared_storage: self,
             state: Self::INITIAL,
         }
@@ -54,7 +54,7 @@ impl<T> StateMachineSharedStorage for T where T: StateMachine {}
 /// A state machine needs to be initialized before it can handle events. This
 /// can be done by calling the [`init`](Self::init) method on it. This will
 /// execute all the entry actions into the initial state.
-pub struct UninitializedStateMachine<M>
+pub struct UnInitializedStateMachine<M>
 where
     M: StateMachine,
 {
@@ -62,7 +62,7 @@ where
     state: <M as StateMachine>::State,
 }
 
-impl<M> UninitializedStateMachine<M>
+impl<M> UnInitializedStateMachine<M>
 where
     M: StateMachine,
 {
@@ -90,8 +90,8 @@ where
     /// // state machine.
     /// let initialized_state_machine = uninitialized_state_machine.init();
     /// ```
-    pub fn init(self) -> InitializedStatemachine<M> {
-        let mut state_machine: InitializedStatemachine<M> = InitializedStatemachine {
+    pub fn init(self) -> InitializedStateMachine<M> {
+        let mut state_machine: InitializedStateMachine<M> = InitializedStateMachine {
             shared_storage: self.shared_storage,
             state: self.state,
         };
@@ -101,7 +101,7 @@ where
 }
 
 /// A state machine that has been initialized.
-pub struct InitializedStatemachine<M>
+pub struct InitializedStateMachine<M>
 where
     M: StateMachine,
 {
@@ -109,7 +109,7 @@ where
     state: <M as StateMachine>::State,
 }
 
-impl<M> InitializedStatemachine<M>
+impl<M> InitializedStateMachine<M>
 where
     M: StateMachine,
 {
@@ -163,7 +163,7 @@ where
     }
 }
 
-impl<'a, M> InitializedStatemachine<M>
+impl<'a, M> InitializedStateMachine<M>
 where
     M: StateMachine<Event<'a> = ()>,
 {
@@ -173,7 +173,7 @@ where
     }
 }
 
-impl<M> Default for InitializedStatemachine<M>
+impl<M> Default for InitializedStateMachine<M>
 where
     M: StateMachine + Default,
 {
@@ -185,7 +185,7 @@ where
     }
 }
 
-impl<M> core::ops::Deref for InitializedStatemachine<M>
+impl<M> core::ops::Deref for InitializedStateMachine<M>
 where
     M: StateMachine,
 {
@@ -196,7 +196,7 @@ where
     }
 }
 
-impl<M> core::ops::DerefMut for InitializedStatemachine<M>
+impl<M> core::ops::DerefMut for InitializedStateMachine<M>
 where
     M: StateMachine,
 {


### PR DESCRIPTION
This PR fixes …
- a couple of typos in the documentation comments
- a typo in `InitializedStatemachine<T>`, renaming it to `InitializedStateMachine<T>`