### PR TITLE
Add After dispatch hook and Before transition, rename existing hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,13 +250,13 @@ state_machine.handle_with_context(&Event::TimerElapsed, &mut context);
 
 For logging purposes you can define two callbacks that will be called at specific points during state machine execution.
 
-- `on_dispatch` is called before an event is dispatched to a specific state or superstate.
+- `before_dispatch` is called before an event is dispatched to a specific state or superstate.
 - `on_transition` is called after a transition has occured.
 
 ```rust
 #[state_machine(
     initial = "State::on()",
-    on_dispatch = "Self::on_dispatch",
+    before_dispatch = "Self::before_dispatch",
     on_transition = "Self::on_transition",
     state(derive(Debug)),
     superstate(derive(Debug))
@@ -270,7 +270,7 @@ impl Blinky {
         println!("transitioned from `{:?}` to `{:?}`", source, target);
     }
 
-    fn on_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
+    fn before_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
         println!("dispatched `{:?}` to `{:?}`", event, state);
     }
 }

--- a/README.md
+++ b/README.md
@@ -270,20 +270,20 @@ impl Blinky {
 }
 
 impl Blinky {
-    fn before_dispatch(&mut self, source: &State, target: &State) {
+    fn before_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
+        println!("before dispatched `{:?}` to `{:?}`", event, state);
+    }
+
+    fn after_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
+        println!("after dispatched `{:?}` to `{:?}`", event, state);
+    }
+
+    fn before_transition(&mut self, source: &State, target: &State) {
         println!("before transitioned from `{:?}` to `{:?}`", source, target);
     }
 
     fn after_transition(&mut self, source: &State, target: &State) {
         println!("after transitioned from `{:?}` to `{:?}`", source, target);
-    }
-
-    fn before_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
-        println!("before dispatched `{:?}` to `{:?}`", event, state);
-    }
-
-    fn after_transition(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
-        println!("after dispatched `{:?}` to `{:?}`", event, state);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -251,12 +251,16 @@ state_machine.handle_with_context(&Event::TimerElapsed, &mut context);
 For logging purposes you can define two callbacks that will be called at specific points during state machine execution.
 
 - `before_dispatch` is called before an event is dispatched to a specific state or superstate.
+- `after_dispatch` is called after an event is dispatched to a specific state or superstate.
+- `before_transition` is called before a transition has occured.
 - `after_transition` is called after a transition has occured.
 
 ```rust
 #[state_machine(
     initial = "State::on()",
     before_dispatch = "Self::before_dispatch",
+    after_dispatch = "Self::after_dispatch",
+    before_transition = "Self::before_transition",
     after_transition = "Self::after_transition",
     state(derive(Debug)),
     superstate(derive(Debug))
@@ -266,12 +270,20 @@ impl Blinky {
 }
 
 impl Blinky {
+    fn before_dispatch(&mut self, source: &State, target: &State) {
+        println!("before transitioned from `{:?}` to `{:?}`", source, target);
+    }
+
     fn after_transition(&mut self, source: &State, target: &State) {
-        println!("transitioned from `{:?}` to `{:?}`", source, target);
+        println!("after transitioned from `{:?}` to `{:?}`", source, target);
     }
 
     fn before_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
-        println!("dispatched `{:?}` to `{:?}`", event, state);
+        println!("before dispatched `{:?}` to `{:?}`", event, state);
+    }
+
+    fn after_transition(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
+        println!("after dispatched `{:?}` to `{:?}`", event, state);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -251,13 +251,13 @@ state_machine.handle_with_context(&Event::TimerElapsed, &mut context);
 For logging purposes you can define two callbacks that will be called at specific points during state machine execution.
 
 - `before_dispatch` is called before an event is dispatched to a specific state or superstate.
-- `on_transition` is called after a transition has occured.
+- `after_transition` is called after a transition has occured.
 
 ```rust
 #[state_machine(
     initial = "State::on()",
     before_dispatch = "Self::before_dispatch",
-    on_transition = "Self::on_transition",
+    after_transition = "Self::after_transition",
     state(derive(Debug)),
     superstate(derive(Debug))
 )]
@@ -266,7 +266,7 @@ impl Blinky {
 }
 
 impl Blinky {
-    fn on_transition(&mut self, source: &State, target: &State) {
+    fn after_transition(&mut self, source: &State, target: &State) {
         println!("transitioned from `{:?}` to `{:?}`", source, target);
     }
 

--- a/examples/macro/async_blinky/src/main.rs
+++ b/examples/macro/async_blinky/src/main.rs
@@ -32,7 +32,9 @@ pub enum Event {
     // Set the `before_dispatch` callback.
     before_dispatch = "Self::before_dispatch",
     // Set the `before_dispatch` callback.
-    after_dispatch = "Self::after_dispatch"
+    after_dispatch = "Self::after_dispatch",
+    // Set the `before_dispatch` callback.
+    before_transition = "Self::before_transition"
 )]
 impl Blinky {
     #[action]
@@ -82,15 +84,19 @@ impl Blinky {
 impl Blinky {
     // The `after_transition` callback that will be called after every transition.
     fn after_transition(&mut self, source: &State, target: &State) {
-        println!("transitioned from `{source:?}` to `{target:?}`");
+        println!("after transitioned from `{source:?}` to `{target:?}`");
+    }
+
+    fn before_transition(&mut self, source: &State, target: &State) {
+        println!("after transitioned from `{source:?}` to `{target:?}`");
     }
 
     fn before_dispatch(&mut self, state: StateOrSuperstate<Self>, event: &Event) {
-        println!("dispatching `{event:?}` to `{state:?}`");
+        println!("before dispatching `{event:?}` to `{state:?}`");
     }
 
     fn after_dispatch(&mut self, state: StateOrSuperstate<Self>, event: &Event) {
-        println!("dispatched `{event:?}` to `{state:?}`");
+        println!("after dispatched `{event:?}` to `{state:?}`");
     }
 }
 

--- a/examples/macro/async_blinky/src/main.rs
+++ b/examples/macro/async_blinky/src/main.rs
@@ -27,8 +27,8 @@ pub enum Event {
     state(derive(Debug)),
     // Derive the Debug trait on the `Superstate` enum.
     superstate(derive(Debug)),
-    // Set the `on_transition` callback.
-    on_transition = "Self::on_transition",
+    // Set the `after_transition` callback.
+    after_transition = "Self::after_transition",
     // Set the `before_dispatch` callback.
     before_dispatch = "Self::before_dispatch",
     // Set the `before_dispatch` callback.
@@ -80,8 +80,8 @@ impl Blinky {
 }
 
 impl Blinky {
-    // The `on_transition` callback that will be called after every transition.
-    fn on_transition(&mut self, source: &State, target: &State) {
+    // The `after_transition` callback that will be called after every transition.
+    fn after_transition(&mut self, source: &State, target: &State) {
         println!("transitioned from `{source:?}` to `{target:?}`");
     }
 

--- a/examples/macro/async_blinky/src/main.rs
+++ b/examples/macro/async_blinky/src/main.rs
@@ -29,9 +29,9 @@ pub enum Event {
     superstate(derive(Debug)),
     // Set the `on_transition` callback.
     on_transition = "Self::on_transition",
-    // Set the `on_dispatch` callback.
-    on_dispatch = "Self::on_dispatch",
-    // Set the `on_dispatch` callback.
+    // Set the `before_dispatch` callback.
+    before_dispatch = "Self::before_dispatch",
+    // Set the `before_dispatch` callback.
     after_dispatch = "Self::after_dispatch"
 )]
 impl Blinky {
@@ -85,7 +85,7 @@ impl Blinky {
         println!("transitioned from `{source:?}` to `{target:?}`");
     }
 
-    fn on_dispatch(&mut self, state: StateOrSuperstate<Self>, event: &Event) {
+    fn before_dispatch(&mut self, state: StateOrSuperstate<Self>, event: &Event) {
         println!("dispatching `{event:?}` to `{state:?}`");
     }
 

--- a/examples/macro/async_blinky/src/main.rs
+++ b/examples/macro/async_blinky/src/main.rs
@@ -30,7 +30,9 @@ pub enum Event {
     // Set the `on_transition` callback.
     on_transition = "Self::on_transition",
     // Set the `on_dispatch` callback.
-    on_dispatch = "Self::on_dispatch"
+    on_dispatch = "Self::on_dispatch",
+    // Set the `on_dispatch` callback.
+    after_dispatch = "Self::after_dispatch"
 )]
 impl Blinky {
     #[action]
@@ -85,6 +87,10 @@ impl Blinky {
 
     fn on_dispatch(&mut self, state: StateOrSuperstate<Self>, event: &Event) {
         println!("dispatching `{event:?}` to `{state:?}`");
+    }
+
+    fn after_dispatch(&mut self, state: StateOrSuperstate<Self>, event: &Event) {
+        println!("dispatched `{event:?}` to `{state:?}`");
     }
 }
 

--- a/examples/macro/blinky/src/main.rs
+++ b/examples/macro/blinky/src/main.rs
@@ -27,8 +27,8 @@ pub enum Event {
     superstate(derive(Debug)),
     // Set the `on_transition` callback.
     on_transition = "Self::on_transition",
-    // Set the `on_dispatch` callback.
-    on_dispatch = "Self::on_dispatch"
+    // Set the `before_dispatch` callback.
+    before_dispatch = "Self::before_dispatch"
 )]
 impl Blinky {
     /// The `#[state]` attibute marks this as a state handler.  By default the
@@ -78,7 +78,7 @@ impl Blinky {
         println!("transitioned from `{source:?}` to `{target:?}`");
     }
 
-    fn on_dispatch(&mut self, state: StateOrSuperstate<Self>, event: &Event) {
+    fn before_dispatch(&mut self, state: StateOrSuperstate<Self>, event: &Event) {
         println!("dispatching `{event:?}` to `{state:?}`");
     }
 }

--- a/examples/macro/blinky/src/main.rs
+++ b/examples/macro/blinky/src/main.rs
@@ -25,8 +25,8 @@ pub enum Event {
     state(derive(Debug)),
     // Derive the Debug trait on the `Superstate` enum.
     superstate(derive(Debug)),
-    // Set the `on_transition` callback.
-    on_transition = "Self::on_transition",
+    // Set the `after_transition` callback.
+    after_transition = "Self::after_transition",
     // Set the `before_dispatch` callback.
     before_dispatch = "Self::before_dispatch"
 )]
@@ -73,8 +73,8 @@ impl Blinky {
 }
 
 impl Blinky {
-    // The `on_transition` callback that will be called after every transition.
-    fn on_transition(&mut self, source: &State, target: &State) {
+    // The `after_transition` callback that will be called after every transition.
+    fn after_transition(&mut self, source: &State, target: &State) {
         println!("transitioned from `{source:?}` to `{target:?}`");
     }
 

--- a/examples/macro/history/src/main.rs
+++ b/examples/macro/history/src/main.rs
@@ -14,12 +14,12 @@ pub struct Dishwasher {
 
 #[state_machine(
     initial = "State::idle()",
-    on_transition = "Self::on_transition",
+    after_transition = "Self::after_transition",
     state(derive(Debug, Clone))
 )]
 impl Dishwasher {
     // On every transition we update the previous state, so we can transition back to it.
-    fn on_transition(&mut self, source: &State, _target: &State) {
+    fn after_transition(&mut self, source: &State, _target: &State) {
         // println!("transitioned from `{:?}` to `{:?}`", source, _target);
         self.previous_state = source.clone();
     }

--- a/examples/no_macro/basic/src/main.rs
+++ b/examples/no_macro/basic/src/main.rs
@@ -33,7 +33,7 @@ impl IntoStateMachine for Blinky {
     const INITIAL: State = State::Off;
 
     /// This method is called on every transition of the state machine.
-    const after_transition: fn(&mut Self, &Self::State, &Self::State) = |_, source, target| {
+    const AFTER_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = |_, source, target| {
         println!("transitioned from {source:?} to {target:?}");
     };
 }

--- a/examples/no_macro/basic/src/main.rs
+++ b/examples/no_macro/basic/src/main.rs
@@ -33,7 +33,7 @@ impl IntoStateMachine for Blinky {
     const INITIAL: State = State::Off;
 
     /// This method is called on every transition of the state machine.
-    const ON_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = |_, source, target| {
+    const after_transition: fn(&mut Self, &Self::State, &Self::State) = |_, source, target| {
         println!("transitioned from {source:?} to {target:?}");
     };
 }

--- a/examples/no_macro/history/src/main.rs
+++ b/examples/no_macro/history/src/main.rs
@@ -40,7 +40,7 @@ impl IntoStateMachine for Dishwasher {
 
     // On every transition we update the previous state, so we can
     // transition back to it.
-    const ON_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = |shared, source, target| {
+    const after_transition: fn(&mut Self, &Self::State, &Self::State) = |shared, source, target| {
         shared.previous_state = source.clone();
     };
 }

--- a/examples/no_macro/history/src/main.rs
+++ b/examples/no_macro/history/src/main.rs
@@ -40,7 +40,7 @@ impl IntoStateMachine for Dishwasher {
 
     // On every transition we update the previous state, so we can
     // transition back to it.
-    const after_transition: fn(&mut Self, &Self::State, &Self::State) = |shared, source, target| {
+    const AFTER_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = |shared, source, target| {
         shared.previous_state = source.clone();
     };
 }

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "statig_macro"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.66"
 authors = ["Maxim Deloof"]

--- a/macro/src/analyze.rs
+++ b/macro/src/analyze.rs
@@ -52,6 +52,8 @@ pub struct StateMachine {
     pub on_transition: Option<Path>,
     /// Optional `on_dispatch` callback.
     pub on_dispatch: Option<Path>,
+    /// Optional `after_dispatch` callback.
+    pub after_dispatch: Option<Path>,
 }
 
 /// Information regarding a state.
@@ -181,6 +183,7 @@ pub fn analyze_state_machine(attribute_args: &AttributeArgs, item_impl: &ItemImp
 
     let mut on_transition = None;
     let mut on_dispatch = None;
+    let mut after_dispatch = None;
 
     let mut visibility = parse_quote!(pub);
     let mut event_ident = parse_quote!(event);
@@ -228,6 +231,14 @@ pub fn analyze_state_machine(attribute_args: &AttributeArgs, item_impl: &ItemImp
                 if name_value.path.is_ident("on_dispatch") =>
             {
                 on_dispatch = match &name_value.lit {
+                    Lit::Str(input_pat) => Some(input_pat.parse().unwrap()),
+                    _ => abort!(name_value, "must be a string literal"),
+                }
+            }
+            NestedMeta::Meta(Meta::NameValue(name_value))
+                if name_value.path.is_ident("after_dispatch") =>
+            {
+                after_dispatch = match &name_value.lit {
                     Lit::Str(input_pat) => Some(input_pat.parse().unwrap()),
                     _ => abort!(name_value, "must be a string literal"),
                 }
@@ -340,6 +351,7 @@ pub fn analyze_state_machine(attribute_args: &AttributeArgs, item_impl: &ItemImp
         superstate_ident,
         superstate_derives,
         on_dispatch,
+        after_dispatch,
         on_transition,
         event_ident,
         context_ident,
@@ -661,6 +673,7 @@ fn valid_state_analyze() {
         superstate_derives,
         on_transition,
         on_dispatch,
+        after_dispatch,
         event_ident,
         context_ident,
         visibility,

--- a/macro/src/analyze.rs
+++ b/macro/src/analyze.rs
@@ -50,8 +50,8 @@ pub struct StateMachine {
     pub visibility: Visibility,
     /// Optional `on_transition` callback.
     pub on_transition: Option<Path>,
-    /// Optional `on_dispatch` callback.
-    pub on_dispatch: Option<Path>,
+    /// Optional `before_dispatch` callback.
+    pub before_dispatch: Option<Path>,
     /// Optional `after_dispatch` callback.
     pub after_dispatch: Option<Path>,
 }
@@ -182,7 +182,7 @@ pub fn analyze_state_machine(attribute_args: &AttributeArgs, item_impl: &ItemImp
     let mut superstate_derives = Vec::new();
 
     let mut on_transition = None;
-    let mut on_dispatch = None;
+    let mut before_dispatch = None;
     let mut after_dispatch = None;
 
     let mut visibility = parse_quote!(pub);
@@ -228,9 +228,9 @@ pub fn analyze_state_machine(attribute_args: &AttributeArgs, item_impl: &ItemImp
                 }
             }
             NestedMeta::Meta(Meta::NameValue(name_value))
-                if name_value.path.is_ident("on_dispatch") =>
+                if name_value.path.is_ident("before_dispatch") =>
             {
-                on_dispatch = match &name_value.lit {
+                before_dispatch = match &name_value.lit {
                     Lit::Str(input_pat) => Some(input_pat.parse().unwrap()),
                     _ => abort!(name_value, "must be a string literal"),
                 }
@@ -350,7 +350,7 @@ pub fn analyze_state_machine(attribute_args: &AttributeArgs, item_impl: &ItemImp
         state_derives,
         superstate_ident,
         superstate_derives,
-        on_dispatch,
+        before_dispatch,
         after_dispatch,
         on_transition,
         event_ident,
@@ -657,7 +657,8 @@ fn valid_state_analyze() {
     let superstate_ident = parse_quote!(Superstate);
     let superstate_derives = vec![parse_quote!(Copy), parse_quote!(Clone)];
     let on_transition = None;
-    let on_dispatch = None;
+    let before_dispatch = None;
+    let after_dispatch = None;
     let event_ident = parse_quote!(event);
     let context_ident = parse_quote!(context);
     let visibility = parse_quote!(pub);
@@ -672,7 +673,7 @@ fn valid_state_analyze() {
         superstate_ident,
         superstate_derives,
         on_transition,
-        on_dispatch,
+        before_dispatch,
         after_dispatch,
         event_ident,
         context_ident,

--- a/macro/src/analyze.rs
+++ b/macro/src/analyze.rs
@@ -48,8 +48,8 @@ pub struct StateMachine {
     pub context_ident: Ident,
     /// The visibility of the derived types.
     pub visibility: Visibility,
-    /// Optional `on_transition` callback.
-    pub on_transition: Option<Path>,
+    /// Optional `after_transition` callback.
+    pub after_transition: Option<Path>,
     /// Optional `before_dispatch` callback.
     pub before_dispatch: Option<Path>,
     /// Optional `after_dispatch` callback.
@@ -181,7 +181,7 @@ pub fn analyze_state_machine(attribute_args: &AttributeArgs, item_impl: &ItemImp
     let mut superstate_ident = parse_quote!(Superstate);
     let mut superstate_derives = Vec::new();
 
-    let mut on_transition = None;
+    let mut after_transition = None;
     let mut before_dispatch = None;
     let mut after_dispatch = None;
 
@@ -220,9 +220,9 @@ pub fn analyze_state_machine(attribute_args: &AttributeArgs, item_impl: &ItemImp
                 }
             }
             NestedMeta::Meta(Meta::NameValue(name_value))
-                if name_value.path.is_ident("on_transition") =>
+                if name_value.path.is_ident("after_transition") =>
             {
-                on_transition = match &name_value.lit {
+                after_transition = match &name_value.lit {
                     Lit::Str(input_pat) => Some(input_pat.parse().unwrap()),
                     _ => abort!(name_value, "must be a string literal"),
                 }
@@ -352,7 +352,7 @@ pub fn analyze_state_machine(attribute_args: &AttributeArgs, item_impl: &ItemImp
         superstate_derives,
         before_dispatch,
         after_dispatch,
-        on_transition,
+        after_transition,
         event_ident,
         context_ident,
         visibility,
@@ -656,7 +656,7 @@ fn valid_state_analyze() {
     let state_derives = vec![parse_quote!(Copy), parse_quote!(Clone)];
     let superstate_ident = parse_quote!(Superstate);
     let superstate_derives = vec![parse_quote!(Copy), parse_quote!(Clone)];
-    let on_transition = None;
+    let after_transition = None;
     let before_dispatch = None;
     let after_dispatch = None;
     let event_ident = parse_quote!(event);
@@ -672,7 +672,7 @@ fn valid_state_analyze() {
         state_derives,
         superstate_ident,
         superstate_derives,
-        on_transition,
+        after_transition,
         before_dispatch,
         after_dispatch,
         event_ident,

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -59,6 +59,13 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
         Mode::Awaitable => quote!(awaitable),
     };
 
+    let before_transition = match &ir.state_machine.before_transition {
+        None => quote!(),
+        Some(before_transition) => quote!(
+            const before_transition: fn(&mut Self, &Self::State, &Self::State) = #before_transition;
+        ),
+    };
+
     let after_transition = match &ir.state_machine.after_transition {
         None => quote!(),
         Some(after_transition) => quote!(
@@ -88,6 +95,7 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
             type Superstate<#superstate_lifetime> = #superstate_ident #superstate_generics ;
             const INITIAL: #state_ident #state_generics = #initial_state;
 
+            #before_transition
             #after_transition
 
             #before_dispatch

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -72,6 +72,12 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
             const ON_DISPATCH: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) = #on_dispatch;
         ),
     };
+    let after_dispatch = match &ir.state_machine.after_dispatch {
+        None => quote!(),
+        Some(after_dispatch) => quote!(
+            const AFTER_DISPATCH: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) = #after_dispatch;
+        ),
+    };
 
     parse_quote!(
         impl #impl_generics statig::#mode::IntoStateMachine for #shared_storage_type #where_clause
@@ -85,6 +91,7 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
             #on_transition
 
             #on_dispatch
+            #after_dispatch
         }
     )
 }

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -62,21 +62,21 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
     let before_transition = match &ir.state_machine.before_transition {
         None => quote!(),
         Some(before_transition) => quote!(
-            const before_transition: fn(&mut Self, &Self::State, &Self::State) = #before_transition;
+            const BEFORE_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = #before_transition;
         ),
     };
 
     let after_transition = match &ir.state_machine.after_transition {
         None => quote!(),
         Some(after_transition) => quote!(
-            const after_transition: fn(&mut Self, &Self::State, &Self::State) = #after_transition;
+            const AFTER_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = #after_transition;
         ),
     };
 
     let before_dispatch = match &ir.state_machine.before_dispatch {
         None => quote!(),
         Some(before_dispatch) => quote!(
-            const before_dispatch: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) = #before_dispatch;
+            const BEFORE_DISPATCH: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) = #before_dispatch;
         ),
     };
     let after_dispatch = match &ir.state_machine.after_dispatch {

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -66,10 +66,10 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
         ),
     };
 
-    let on_dispatch = match &ir.state_machine.on_dispatch {
+    let before_dispatch = match &ir.state_machine.before_dispatch {
         None => quote!(),
-        Some(on_dispatch) => quote!(
-            const ON_DISPATCH: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) = #on_dispatch;
+        Some(before_dispatch) => quote!(
+            const before_dispatch: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) = #before_dispatch;
         ),
     };
     let after_dispatch = match &ir.state_machine.after_dispatch {
@@ -90,7 +90,7 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
 
             #on_transition
 
-            #on_dispatch
+            #before_dispatch
             #after_dispatch
         }
     )

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -59,10 +59,10 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
         Mode::Awaitable => quote!(awaitable),
     };
 
-    let on_transition = match &ir.state_machine.on_transition {
+    let after_transition = match &ir.state_machine.after_transition {
         None => quote!(),
-        Some(on_transition) => quote!(
-            const ON_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = #on_transition;
+        Some(after_transition) => quote!(
+            const after_transition: fn(&mut Self, &Self::State, &Self::State) = #after_transition;
         ),
     };
 
@@ -88,7 +88,7 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
             type Superstate<#superstate_lifetime> = #superstate_ident #superstate_generics ;
             const INITIAL: #state_ident #state_generics = #initial_state;
 
-            #on_transition
+            #after_transition
 
             #before_dispatch
             #after_dispatch

--- a/macro/src/lower.rs
+++ b/macro/src/lower.rs
@@ -60,6 +60,8 @@ pub struct StateMachine {
     pub on_transition: Option<Path>,
     /// The path of the `on_dispatch` callback.
     pub on_dispatch: Option<Path>,
+    /// The path of the `after_dispatch` callback.
+    pub after_dispatch: Option<Path>,
     /// The visibility for the derived types,
     pub visibility: Visibility,
     /// The external input pattern.
@@ -138,6 +140,7 @@ pub fn lower(model: &Model) -> Ir {
     let superstate_ident = model.state_machine.superstate_ident.clone();
     let on_transition = model.state_machine.on_transition.clone();
     let on_dispatch = model.state_machine.on_dispatch.clone();
+    let after_dispatch = model.state_machine.after_dispatch.clone();
     let event_ident = model.state_machine.event_ident.clone();
     let context_ident = model.state_machine.context_ident.clone();
     let shared_storage_type = model.state_machine.shared_storage_type.clone();
@@ -422,6 +425,7 @@ pub fn lower(model: &Model) -> Ir {
         superstate_generics,
         on_transition,
         on_dispatch,
+        after_dispatch,
         visibility,
         event_ident,
         context_ident,
@@ -709,6 +713,7 @@ fn create_analyze_state_machine() -> analyze::StateMachine {
         superstate_derives: vec![parse_quote!(Copy), parse_quote!(Clone)],
         on_transition: None,
         on_dispatch: None,
+        after_dispatch: None,
         visibility: parse_quote!(pub),
         event_ident: parse_quote!(input),
         context_ident: parse_quote!(context),
@@ -734,6 +739,7 @@ fn create_lower_state_machine() -> StateMachine {
         superstate_generics,
         on_transition: None,
         on_dispatch: None,
+        after_dispatch: None,
         visibility: parse_quote!(pub),
         event_ident: parse_quote!(input),
         context_ident: parse_quote!(context),

--- a/macro/src/lower.rs
+++ b/macro/src/lower.rs
@@ -58,8 +58,8 @@ pub struct StateMachine {
     pub superstate_generics: Generics,
     /// The path of the `on_transition` callback.
     pub on_transition: Option<Path>,
-    /// The path of the `on_dispatch` callback.
-    pub on_dispatch: Option<Path>,
+    /// The path of the `before_dispatch` callback.
+    pub before_dispatch: Option<Path>,
     /// The path of the `after_dispatch` callback.
     pub after_dispatch: Option<Path>,
     /// The visibility for the derived types,
@@ -139,7 +139,7 @@ pub fn lower(model: &Model) -> Ir {
     let state_ident = model.state_machine.state_ident.clone();
     let superstate_ident = model.state_machine.superstate_ident.clone();
     let on_transition = model.state_machine.on_transition.clone();
-    let on_dispatch = model.state_machine.on_dispatch.clone();
+    let before_dispatch = model.state_machine.before_dispatch.clone();
     let after_dispatch = model.state_machine.after_dispatch.clone();
     let event_ident = model.state_machine.event_ident.clone();
     let context_ident = model.state_machine.context_ident.clone();
@@ -424,7 +424,7 @@ pub fn lower(model: &Model) -> Ir {
         superstate_derives,
         superstate_generics,
         on_transition,
-        on_dispatch,
+        before_dispatch,
         after_dispatch,
         visibility,
         event_ident,
@@ -712,7 +712,7 @@ fn create_analyze_state_machine() -> analyze::StateMachine {
         superstate_ident: parse_quote!(Superstate),
         superstate_derives: vec![parse_quote!(Copy), parse_quote!(Clone)],
         on_transition: None,
-        on_dispatch: None,
+        before_dispatch: None,
         after_dispatch: None,
         visibility: parse_quote!(pub),
         event_ident: parse_quote!(input),
@@ -738,7 +738,7 @@ fn create_lower_state_machine() -> StateMachine {
         superstate_derives: vec![parse_quote!(Copy), parse_quote!(Clone)],
         superstate_generics,
         on_transition: None,
-        on_dispatch: None,
+        before_dispatch: None,
         after_dispatch: None,
         visibility: parse_quote!(pub),
         event_ident: parse_quote!(input),

--- a/macro/src/lower.rs
+++ b/macro/src/lower.rs
@@ -56,8 +56,8 @@ pub struct StateMachine {
     pub superstate_derives: Vec<Path>,
     /// The generics associated with the superstate type.
     pub superstate_generics: Generics,
-    /// The path of the `on_transition` callback.
-    pub on_transition: Option<Path>,
+    /// The path of the `after_transition` callback.
+    pub after_transition: Option<Path>,
     /// The path of the `before_dispatch` callback.
     pub before_dispatch: Option<Path>,
     /// The path of the `after_dispatch` callback.
@@ -138,7 +138,7 @@ pub fn lower(model: &Model) -> Ir {
     let initial_state = model.state_machine.initial_state.clone();
     let state_ident = model.state_machine.state_ident.clone();
     let superstate_ident = model.state_machine.superstate_ident.clone();
-    let on_transition = model.state_machine.on_transition.clone();
+    let after_transition = model.state_machine.after_transition.clone();
     let before_dispatch = model.state_machine.before_dispatch.clone();
     let after_dispatch = model.state_machine.after_dispatch.clone();
     let event_ident = model.state_machine.event_ident.clone();
@@ -423,7 +423,7 @@ pub fn lower(model: &Model) -> Ir {
         superstate_ident,
         superstate_derives,
         superstate_generics,
-        on_transition,
+        after_transition,
         before_dispatch,
         after_dispatch,
         visibility,
@@ -711,7 +711,7 @@ fn create_analyze_state_machine() -> analyze::StateMachine {
         state_derives: vec![parse_quote!(Copy), parse_quote!(Clone)],
         superstate_ident: parse_quote!(Superstate),
         superstate_derives: vec![parse_quote!(Copy), parse_quote!(Clone)],
-        on_transition: None,
+        after_transition: None,
         before_dispatch: None,
         after_dispatch: None,
         visibility: parse_quote!(pub),
@@ -737,7 +737,7 @@ fn create_lower_state_machine() -> StateMachine {
         superstate_ident: parse_quote!(Superstate),
         superstate_derives: vec![parse_quote!(Copy), parse_quote!(Clone)],
         superstate_generics,
-        on_transition: None,
+        after_transition: None,
         before_dispatch: None,
         after_dispatch: None,
         visibility: parse_quote!(pub),

--- a/macro/src/lower.rs
+++ b/macro/src/lower.rs
@@ -56,6 +56,8 @@ pub struct StateMachine {
     pub superstate_derives: Vec<Path>,
     /// The generics associated with the superstate type.
     pub superstate_generics: Generics,
+    /// The path of the `before_transition` callback.
+    pub before_transition: Option<Path>,
     /// The path of the `after_transition` callback.
     pub after_transition: Option<Path>,
     /// The path of the `before_dispatch` callback.
@@ -138,6 +140,7 @@ pub fn lower(model: &Model) -> Ir {
     let initial_state = model.state_machine.initial_state.clone();
     let state_ident = model.state_machine.state_ident.clone();
     let superstate_ident = model.state_machine.superstate_ident.clone();
+    let before_transition = model.state_machine.before_transition.clone();
     let after_transition = model.state_machine.after_transition.clone();
     let before_dispatch = model.state_machine.before_dispatch.clone();
     let after_dispatch = model.state_machine.after_dispatch.clone();
@@ -423,6 +426,7 @@ pub fn lower(model: &Model) -> Ir {
         superstate_ident,
         superstate_derives,
         superstate_generics,
+        before_transition,
         after_transition,
         before_dispatch,
         after_dispatch,
@@ -711,6 +715,7 @@ fn create_analyze_state_machine() -> analyze::StateMachine {
         state_derives: vec![parse_quote!(Copy), parse_quote!(Clone)],
         superstate_ident: parse_quote!(Superstate),
         superstate_derives: vec![parse_quote!(Copy), parse_quote!(Clone)],
+        before_transition: None,
         after_transition: None,
         before_dispatch: None,
         after_dispatch: None,
@@ -737,6 +742,7 @@ fn create_lower_state_machine() -> StateMachine {
         superstate_ident: parse_quote!(Superstate),
         superstate_derives: vec![parse_quote!(Copy), parse_quote!(Clone)],
         superstate_generics,
+        before_transition: None,
         after_transition: None,
         before_dispatch: None,
         after_dispatch: None,

--- a/statig/Cargo.toml
+++ b/statig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "statig"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.66"
 authors = ["Maxim Deloof"]

--- a/statig/Cargo.toml
+++ b/statig/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/mdeloof/statig"
 keywords = ["fsm", "hsm", "statechart", "state-machine", "embedded"]
 
 [dependencies]
-statig_macro = { path = "../macro", version = "0.3.0", optional = true }
+statig_macro = { path = "../macro", version = "0.4.0", optional = true }
 serde = { version = "1.0.152", optional = true }
 bevy_ecs = { version = "0.12.1", optional = true }
 

--- a/statig/Cargo.toml
+++ b/statig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "statig"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.66"
 authors = ["Maxim Deloof"]
@@ -13,7 +13,7 @@ keywords = ["fsm", "hsm", "statechart", "state-machine", "embedded"]
 [dependencies]
 statig_macro = { path = "../macro", version = "0.3.0", optional = true }
 serde = { version = "1.0.152", optional = true }
-bevy_ecs = { version = "0.9.1", optional = true }
+bevy_ecs = { version = "0.12.1", optional = true }
 
 
 [dev-dependencies]

--- a/statig/src/awaitable/state.rs
+++ b/statig/src/awaitable/state.rs
@@ -111,7 +111,7 @@ where
         context: &'fut mut M::Context<'_>,
     ) -> Pin<Box<dyn Future<Output = Response<Self>> + 'fut + Send>> {
         let future = async move {
-            M::ON_DISPATCH(shared_storage, StateOrSuperstate::State(self), event);
+            M::before_dispatch(shared_storage, StateOrSuperstate::State(self), event);
 
             let response = self.call_handler(shared_storage, event, context).await;
 
@@ -121,7 +121,7 @@ where
                 Response::Handled => Response::Handled,
                 Response::Super => match self.superstate() {
                     Some(mut superstate) => {
-                        M::ON_DISPATCH(
+                        M::before_dispatch(
                             shared_storage,
                             StateOrSuperstate::Superstate(&superstate),
                             event,

--- a/statig/src/awaitable/state.rs
+++ b/statig/src/awaitable/state.rs
@@ -115,6 +115,8 @@ where
 
             let response = self.call_handler(shared_storage, event, context).await;
 
+            M::AFTER_DISPATCH(shared_storage, StateOrSuperstate::State(self), event);
+
             match response {
                 Response::Handled => Response::Handled,
                 Response::Super => match self.superstate() {
@@ -125,7 +127,15 @@ where
                             event,
                         );
 
-                        superstate.handle(shared_storage, event, context).await
+                        let response = superstate.handle(shared_storage, event, context).await;
+
+                        M::AFTER_DISPATCH(
+                            shared_storage,
+                            StateOrSuperstate::Superstate(&superstate),
+                            event,
+                        );
+
+                        response
                     }
                     None => Response::Super,
                 },

--- a/statig/src/awaitable/state.rs
+++ b/statig/src/awaitable/state.rs
@@ -111,7 +111,7 @@ where
         context: &'fut mut M::Context<'_>,
     ) -> Pin<Box<dyn Future<Output = Response<Self>> + 'fut + Send>> {
         let future = async move {
-            M::before_dispatch(shared_storage, StateOrSuperstate::State(self), event);
+            M::BEFORE_DISPATCH(shared_storage, StateOrSuperstate::State(self), event);
 
             let response = self.call_handler(shared_storage, event, context).await;
 
@@ -121,7 +121,7 @@ where
                 Response::Handled => Response::Handled,
                 Response::Super => match self.superstate() {
                     Some(mut superstate) => {
-                        M::before_dispatch(
+                        M::BEFORE_DISPATCH(
                             shared_storage,
                             StateOrSuperstate::Superstate(&superstate),
                             event,

--- a/statig/src/awaitable/superstate.rs
+++ b/statig/src/awaitable/superstate.rs
@@ -117,7 +117,7 @@ where
                 Response::Handled => Response::Handled,
                 Response::Super => match self.superstate() {
                     Some(mut superstate) => {
-                        M::before_dispatch(
+                        M::BEFORE_DISPATCH(
                             shared_storage,
                             StateOrSuperstate::Superstate(&superstate),
                             event,

--- a/statig/src/awaitable/superstate.rs
+++ b/statig/src/awaitable/superstate.rs
@@ -117,7 +117,7 @@ where
                 Response::Handled => Response::Handled,
                 Response::Super => match self.superstate() {
                     Some(mut superstate) => {
-                        M::ON_DISPATCH(
+                        M::before_dispatch(
                             shared_storage,
                             StateOrSuperstate::Superstate(&superstate),
                             event,

--- a/statig/src/awaitable/superstate.rs
+++ b/statig/src/awaitable/superstate.rs
@@ -123,7 +123,15 @@ where
                             event,
                         );
 
-                        superstate.handle(shared_storage, event, context).await
+                        let response = superstate.handle(shared_storage, event, context).await;
+
+                        M::AFTER_DISPATCH(
+                            shared_storage,
+                            StateOrSuperstate::Superstate(&superstate),
+                            event,
+                        );
+
+                        response
                     }
                     None => Response::Super,
                 },

--- a/statig/src/blocking/state.rs
+++ b/statig/src/blocking/state.rs
@@ -96,7 +96,7 @@ where
     where
         Self: Sized,
     {
-        M::ON_DISPATCH(shared_storage, StateOrSuperstate::State(self), event);
+        M::before_dispatch(shared_storage, StateOrSuperstate::State(self), event);
 
         let response = self.call_handler(shared_storage, event, context);
 
@@ -106,7 +106,7 @@ where
             Response::Handled => Response::Handled,
             Response::Super => match self.superstate() {
                 Some(mut superstate) => {
-                    M::ON_DISPATCH(
+                    M::before_dispatch(
                         shared_storage,
                         StateOrSuperstate::Superstate(&superstate),
                         event,

--- a/statig/src/blocking/state.rs
+++ b/statig/src/blocking/state.rs
@@ -96,7 +96,7 @@ where
     where
         Self: Sized,
     {
-        M::before_dispatch(shared_storage, StateOrSuperstate::State(self), event);
+        M::BEFORE_DISPATCH(shared_storage, StateOrSuperstate::State(self), event);
 
         let response = self.call_handler(shared_storage, event, context);
 
@@ -106,7 +106,7 @@ where
             Response::Handled => Response::Handled,
             Response::Super => match self.superstate() {
                 Some(mut superstate) => {
-                    M::before_dispatch(
+                    M::BEFORE_DISPATCH(
                         shared_storage,
                         StateOrSuperstate::Superstate(&superstate),
                         event,

--- a/statig/src/blocking/state.rs
+++ b/statig/src/blocking/state.rs
@@ -100,6 +100,8 @@ where
 
         let response = self.call_handler(shared_storage, event, context);
 
+        M::AFTER_DISPATCH(shared_storage, StateOrSuperstate::State(self), event);
+
         match response {
             Response::Handled => Response::Handled,
             Response::Super => match self.superstate() {
@@ -110,7 +112,15 @@ where
                         event,
                     );
 
-                    superstate.handle(shared_storage, event, context)
+                    let response = superstate.handle(shared_storage, event, context);
+
+                    M::AFTER_DISPATCH(
+                        shared_storage,
+                        StateOrSuperstate::Superstate(&superstate),
+                        event,
+                    );
+
+                    response
                 }
                 None => Response::Super,
             },

--- a/statig/src/blocking/superstate.rs
+++ b/statig/src/blocking/superstate.rs
@@ -103,7 +103,7 @@ where
             Response::Handled => Response::Handled,
             Response::Super => match self.superstate() {
                 Some(mut superstate) => {
-                    M::before_dispatch(
+                    M::BEFORE_DISPATCH(
                         shared_storage,
                         StateOrSuperstate::Superstate(&superstate),
                         event,

--- a/statig/src/blocking/superstate.rs
+++ b/statig/src/blocking/superstate.rs
@@ -109,7 +109,15 @@ where
                         event,
                     );
 
-                    superstate.handle(shared_storage, event, context)
+                    let response = superstate.handle(shared_storage, event, context);
+
+                    M::AFTER_DISPATCH(
+                        shared_storage,
+                        StateOrSuperstate::Superstate(&superstate),
+                        event,
+                    );
+
+                    response
                 }
                 None => Response::Super,
             },

--- a/statig/src/blocking/superstate.rs
+++ b/statig/src/blocking/superstate.rs
@@ -103,7 +103,7 @@ where
             Response::Handled => Response::Handled,
             Response::Super => match self.superstate() {
                 Some(mut superstate) => {
-                    M::ON_DISPATCH(
+                    M::before_dispatch(
                         shared_storage,
                         StateOrSuperstate::Superstate(&superstate),
                         event,

--- a/statig/src/inner.rs
+++ b/statig/src/inner.rs
@@ -51,7 +51,7 @@ where
         self.state
             .enter(&mut self.shared_storage, context, enter_levels);
 
-        M::after_transition(&mut self.shared_storage, &target, &self.state);
+        M::AFTER_TRANSITION(&mut self.shared_storage, &target, &self.state);
     }
 }
 
@@ -105,7 +105,7 @@ where
             .enter(&mut self.shared_storage, context, enter_levels)
             .await;
 
-        M::after_transition(&mut self.shared_storage, &target, &self.state);
+        M::AFTER_TRANSITION(&mut self.shared_storage, &target, &self.state);
     }
 }
 

--- a/statig/src/inner.rs
+++ b/statig/src/inner.rs
@@ -51,7 +51,7 @@ where
         self.state
             .enter(&mut self.shared_storage, context, enter_levels);
 
-        M::ON_TRANSITION(&mut self.shared_storage, &target, &self.state);
+        M::after_transition(&mut self.shared_storage, &target, &self.state);
     }
 }
 
@@ -105,7 +105,7 @@ where
             .enter(&mut self.shared_storage, context, enter_levels)
             .await;
 
-        M::ON_TRANSITION(&mut self.shared_storage, &target, &self.state);
+        M::after_transition(&mut self.shared_storage, &target, &self.state);
     }
 }
 

--- a/statig/src/inner.rs
+++ b/statig/src/inner.rs
@@ -37,6 +37,7 @@ where
 
     /// Transition from the current state to the given target state.
     pub fn transition(&mut self, mut target: M::State, context: &mut M::Context<'_>) {
+        M::BEFORE_TRANSITION(&mut self.shared_storage, &target, &self.state);
         // Get the transition path we need to perform from one state to the next.
         let (exit_levels, enter_levels) = self.state.transition_path(&mut target);
 
@@ -89,6 +90,7 @@ where
 
     /// Transition from the current state to the given target state.
     pub async fn async_transition(&mut self, mut target: M::State, context: &mut M::Context<'_>) {
+        M::BEFORE_TRANSITION(&mut self.shared_storage, &target, &self.state);
         // Get the transition path we need to perform from one state to the next.
         let (exit_levels, enter_levels) = self.state.transition_path(&mut target);
 

--- a/statig/src/into_state_machine.rs
+++ b/statig/src/into_state_machine.rs
@@ -33,5 +33,5 @@ where
         |_, _, _| {};
 
     /// Method that is called *after* every transition.
-    const ON_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = |_, _, _| {};
+    const after_transition: fn(&mut Self, &Self::State, &Self::State) = |_, _, _| {};
 }

--- a/statig/src/into_state_machine.rs
+++ b/statig/src/into_state_machine.rs
@@ -24,7 +24,7 @@ where
 
     /// Method that is called *before* an event is dispatched to a state or
     /// superstate handler.
-    const before_dispatch: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) =
+    const BEFORE_DISPATCH: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) =
         |_, _, _| {};
 
     /// Method that is called *after* an event is dispatched to a state or
@@ -33,8 +33,8 @@ where
         |_, _, _| {};
 
     /// Method that is called *before* every transition.
-    const before_transition: fn(&mut Self, &Self::State, &Self::State) = |_, _, _| {};
+    const BEFORE_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = |_, _, _| {};
 
     /// Method that is called *after* every transition.
-    const after_transition: fn(&mut Self, &Self::State, &Self::State) = |_, _, _| {};
+    const AFTER_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = |_, _, _| {};
 }

--- a/statig/src/into_state_machine.rs
+++ b/statig/src/into_state_machine.rs
@@ -24,7 +24,7 @@ where
 
     /// Method that is called *before* an event is dispatched to a state or
     /// superstate handler.
-    const ON_DISPATCH: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) =
+    const before_dispatch: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) =
         |_, _, _| {};
 
     /// Method that is called *after* an event is dispatched to a state or

--- a/statig/src/into_state_machine.rs
+++ b/statig/src/into_state_machine.rs
@@ -32,6 +32,9 @@ where
     const AFTER_DISPATCH: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) =
         |_, _, _| {};
 
+    /// Method that is called *before* every transition.
+    const before_transition: fn(&mut Self, &Self::State, &Self::State) = |_, _, _| {};
+
     /// Method that is called *after* every transition.
     const after_transition: fn(&mut Self, &Self::State, &Self::State) = |_, _, _| {};
 }

--- a/statig/src/into_state_machine.rs
+++ b/statig/src/into_state_machine.rs
@@ -27,6 +27,11 @@ where
     const ON_DISPATCH: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) =
         |_, _, _| {};
 
+    /// Method that is called *after* an event is dispatched to a state or
+    /// superstate handler.
+    const AFTER_DISPATCH: fn(&mut Self, StateOrSuperstate<'_, '_, Self>, &Self::Event<'_>) =
+        |_, _, _| {};
+
     /// Method that is called *after* every transition.
     const ON_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = |_, _, _| {};
 }

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -380,7 +380,7 @@
 //! For logging purposes you can define two callbacks that will be called at specific
 //! points during state machine execution.
 //!
-//! - `on_dispatch` is called before an event is dispatched to a specific state or superstate.
+//! - `before_dispatch` is called before an event is dispatched to a specific state or superstate.
 //! - `after_dispatch` is called after an event is dispatched to a specific state or superstate.
 //! - `on_transition` is called after a transition has occurred.
 //!
@@ -395,7 +395,7 @@
 //! #
 //! #[state_machine(
 //!     initial = "State::on()",
-//!     on_dispatch = "Self::on_dispatch",
+//!     before_dispatch = "Self::before_dispatch",
 //!     after_dispatch = "Self::after_dispatch",
 //!     on_transition = "Self::on_transition",
 //!     state(derive(Debug)),
@@ -411,7 +411,7 @@
 //!         println!("transitioned from `{:?}` to `{:?}`", source, target);
 //!     }
 //!
-//!     fn on_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
+//!     fn before_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
 //!         println!("dispatched `{:?}` to `{:?}`", event, state);
 //!     }
 //!     fn after_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -382,6 +382,7 @@
 //!
 //! - `before_dispatch` is called before an event is dispatched to a specific state or superstate.
 //! - `after_dispatch` is called after an event is dispatched to a specific state or superstate.
+//! - `before_transition` is called before a transition has occurred.
 //! - `after_transition` is called after a transition has occurred.
 //!
 //! ```

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -451,7 +451,7 @@
 //! }
 //!
 //! # let future = async {
-//! let mut state_machine = Blinky::default().uninitialized_state_machine().init().await;
+//! let mut state_machine = Blinky::default().state_machine();
 //!
 //! state_machine.handle(&Event::TimerElapsed).await;
 //! state_machine.handle(&Event::ButtonPressed).await;

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -408,15 +408,19 @@
 //! }
 //!
 //! impl Blinky {
+//!     fn before_transition(&mut self, source: &State, target: &State) {
+//!         println!("before transition from `{:?}` to `{:?}`", source, target);
+//!     }
+//!
 //!     fn after_transition(&mut self, source: &State, target: &State) {
-//!         println!("transitioned from `{:?}` to `{:?}`", source, target);
+//!         println!("after transition from `{:?}` to `{:?}`", source, target);
 //!     }
 //!
 //!     fn before_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
-//!         println!("dispatched `{:?}` to `{:?}`", event, state);
+//!         println!("before dispatched `{:?}` to `{:?}`", event, state);
 //!     }
 //!     fn after_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
-//!         println!("dispatched `{:?}` to `{:?}`", event, state);
+//!         println!("after dispatched `{:?}` to `{:?}`", event, state);
 //!     }
 //! }
 //! ```

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -381,6 +381,7 @@
 //! points during state machine execution.
 //!
 //! - `on_dispatch` is called before an event is dispatched to a specific state or superstate.
+//! - `after_dispatch` is called after an event is dispatched to a specific state or superstate.
 //! - `on_transition` is called after a transition has occurred.
 //!
 //! ```
@@ -395,6 +396,7 @@
 //! #[state_machine(
 //!     initial = "State::on()",
 //!     on_dispatch = "Self::on_dispatch",
+//!     after_dispatch = "Self::after_dispatch",
 //!     on_transition = "Self::on_transition",
 //!     state(derive(Debug)),
 //!     superstate(derive(Debug))
@@ -410,6 +412,9 @@
 //!     }
 //!
 //!     fn on_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
+//!         println!("dispatched `{:?}` to `{:?}`", event, state);
+//!     }
+//!     fn after_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
 //!         println!("dispatched `{:?}` to `{:?}`", event, state);
 //!     }
 //! }

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -397,6 +397,7 @@
 //!     initial = "State::on()",
 //!     before_dispatch = "Self::before_dispatch",
 //!     after_dispatch = "Self::after_dispatch",
+//!     before_transition = "Self::before_transition",
 //!     after_transition = "Self::after_transition",
 //!     state(derive(Debug)),
 //!     superstate(derive(Debug))

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -382,7 +382,7 @@
 //!
 //! - `before_dispatch` is called before an event is dispatched to a specific state or superstate.
 //! - `after_dispatch` is called after an event is dispatched to a specific state or superstate.
-//! - `on_transition` is called after a transition has occurred.
+//! - `after_transition` is called after a transition has occurred.
 //!
 //! ```
 //! # use statig::prelude::*;
@@ -397,7 +397,7 @@
 //!     initial = "State::on()",
 //!     before_dispatch = "Self::before_dispatch",
 //!     after_dispatch = "Self::after_dispatch",
-//!     on_transition = "Self::on_transition",
+//!     after_transition = "Self::after_transition",
 //!     state(derive(Debug)),
 //!     superstate(derive(Debug))
 //! )]
@@ -407,7 +407,7 @@
 //! }
 //!
 //! impl Blinky {
-//!     fn on_transition(&mut self, source: &State, target: &State) {
+//!     fn after_transition(&mut self, source: &State, target: &State) {
 //!         println!("transitioned from `{:?}` to `{:?}`", source, target);
 //!     }
 //!


### PR DESCRIPTION
Although on_dispatch and on_transition hook are intend to be used for loging in some cases it can be useful to abuse them to have a global even handler that stores some filtered events in self. For that case it sometimes makes sense to be able to store something in self after a state handler is called to for example use it for storing previous values that can be used when a new value comes in to compare too.
