### PR TITLE
Test: Add failing example illustrating mocking issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "examples/macro/generics",
     "examples/macro/async_blinky",
     "examples/macro/async_io",
+    "examples/macro/mocking_demo",
 
     "examples/no_macro/basic",
     "examples/no_macro/blinky",
@@ -22,3 +23,5 @@ members = [
     "examples/no_macro/history",
     "examples/no_macro/calculator",
 ]
+
+resolver = "2"

--- a/examples/macro/mocking_demo/Cargo.toml
+++ b/examples/macro/mocking_demo/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "mocking_demo"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+
+[dependencies]
+mockall_double = "0.3.1"
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.133"
+statig = { path = "../../../statig", features = ["serde", "async"] }
+tokio = { version = "1.41.1", features = ["full"] }
+
+[dev-dependencies]
+mockall = "0.13.1"
+rstest = "0.23.0"

--- a/examples/macro/mocking_demo/src/lib.rs
+++ b/examples/macro/mocking_demo/src/lib.rs
@@ -1,0 +1,129 @@
+#![allow(unused)]
+
+use serde::{Deserialize, Serialize};
+use statig::awaitable::{InitializedStateMachine, UninitializedStateMachine};
+use statig::prelude::*;
+
+mod mockable {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Default)]
+    pub(crate) struct Mockable;
+
+    #[cfg_attr(test, mockall::automock)]
+    impl Mockable {
+        pub(crate) fn should_transition(&self) -> bool {
+            true
+        }
+    }
+}
+
+#[mockall_double::double]
+use mockable::Mockable;
+
+fn mockable_default() -> Mockable {
+    // Allow default for `MockMockable`
+    #[allow(clippy::default_constructed_unit_structs)]
+    Mockable::default()
+}
+
+#[derive(Default, Deserialize, Serialize)]
+pub struct Machine {
+    #[serde(skip, default = "mockable_default")]
+    want_to_mock: Mockable,
+}
+
+#[derive(Default, Deserialize, Serialize)]
+pub struct Event;
+
+#[state_machine(
+    initial = "State::polling()",
+    state(derive(Debug, Serialize, Deserialize, PartialEq, Eq))
+)]
+impl Machine {
+    #[state]
+    async fn polling(&mut self, event: &Event) -> Response<State> {
+        Transition(State::downloading())
+    }
+
+    #[state]
+    async fn downloading(&mut self, event: &Event) -> Response<State> {
+        if self.want_to_mock.should_transition() {
+            Transition(State::installing())
+        } else {
+            Handled
+        }
+    }
+
+    #[state]
+    async fn installing(&mut self, event: &Event) -> Response<State> {
+        Transition(State::polling())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use rstest::fixture;
+    use rstest::rstest;
+    use serde_json::json;
+
+    async fn set_init_state(
+        new_state: String,
+        default_machine: Machine,
+    ) -> InitializedStateMachine<Machine> {
+        // Create the [StateMachine<T>]
+        let machine = default_machine.state_machine();
+
+        // Serialize to a Value
+        let mut intermediate_json = serde_json::to_value(&machine).unwrap();
+
+        // Set the state
+        *intermediate_json.get_mut("state").unwrap() = json!({ new_state: {} });
+
+        // Deserialize the value
+        let machine: UninitializedStateMachine<Machine> =
+            serde_json::from_value(intermediate_json).unwrap();
+
+        // Initialize the StateMachine
+        machine.init().await
+    }
+
+    #[fixture]
+    pub(crate) async fn downloading_fixture() -> InitializedStateMachine<Machine> {
+        let machine = Machine::default();
+        set_init_state("Downloading".to_string(), machine).await
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_init_state(#[future] downloading_fixture: InitializedStateMachine<Machine>) {
+        assert_eq!(*downloading_fixture.await.state(), State::downloading());
+    }
+
+    #[rstest]
+    #[case(false, State::downloading())]
+    #[case(true, State::installing())]
+    #[tokio::test]
+    async fn test_transition_to_installing(
+        #[future] downloading_fixture: InitializedStateMachine<Machine>,
+        #[case] transition_return: bool,
+        #[case] expected_state: State,
+    ) {
+        // Here is the problem, in order to set expectations on the mock I need
+        // to mutate inner. This can't be done when creating the [Machine]
+        // because I can't the mock through serializing which is necessary for
+        // me to set the initial state of the machine.
+        let mut machine = downloading_fixture.await;
+
+        machine
+            .want_to_mock
+            .expect_should_transition()
+            .return_const(transition_return);
+
+        machine.handle(&Event).await;
+
+        assert_eq!(*machine.state(), expected_state,);
+    }
+}


### PR DESCRIPTION
This commit adds an example that demonstrates the difficulty of mocking dependencies in a `statig` state machine when using serialization for state initialization.

The example attempts to:
- Initialize the state machine to a specific state using `serde`.
- Mock a dependency within the state machine.
- Verify the state transition after handling an event.

However, the example fails to build because it's currently impossible to set mock expectations before deserialization due to the lack of `DerefMut` implementations for `UninitializedStateMachine` and `InitializedStateMachine`.

This highlights the need for a solution that allows access to the inner state machine for mock configuration before initialization, potentially by implementing `DerefMut` or providing an alternative mechanism.