### PR TITLE
feat: Implement PartialEq and Eq for Response

### DIFF
--- a/statig/src/response.rs
+++ b/statig/src/response.rs
@@ -10,6 +10,22 @@ pub enum Response<S> {
     Transition(S),
 }
 
+impl<S> PartialEq for Response<S>
+where
+    S: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Handled, Self::Handled) => true,
+            (Self::Super, Self::Super) => true,
+            (Self::Transition(s), Self::Transition(o)) => s == o,
+            _ => false,
+        }
+    }
+}
+
+impl<S> Eq for Response<S> where S: Eq {}
+
 impl<S> Debug for Response<S>
 where
     S: Debug,


### PR DESCRIPTION
Problem: The `Response` type does not impl `PartialEq` or `Eq`, making it difficult to perform equality comparisons in unit tests.

Solution: Impl `PartialEq` and `Eq` for the `Response` type when the associated generic state parameter also impls these traits.

Testing: `cargo test`

Issue: https://github.com/mdeloof/statig/issues/35