### PR TITLE
feat: permit access to StateMachine internal data

### DIFF
--- a/statig/src/awaitable/state_machine.rs
+++ b/statig/src/awaitable/state_machine.rs
@@ -129,6 +129,67 @@ where
     pub fn state(&self) -> &M::State {
         &self.inner.state
     }
+
+    /// Get a reference to the [StateMachine]'s [Inner] storage.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let state_machine = Blinky::default().state_machine();
+    /// assert_eq!(state_machine.inner().shared_storage.led, false);
+    /// assert_eq!(state_machine.inner().state, State::on());
+    /// ```
+    pub fn inner(&self) -> &Inner<M> {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the [StateMachine]'s [Inner] storage.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [StateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut state_machine = Blinky::default().state_machine();
+    ///
+    /// unsafe {
+    ///     state_machine.inner_mut().shared_storage.led = true;
+    ///     state_machine.inner_mut().state = State::on();
+    /// }
+    /// ```
+    pub unsafe fn inner_mut(&mut self) -> &mut Inner<M> {
+        &mut self.inner
+    }
 }
 
 impl<M> Clone for StateMachine<M>
@@ -285,6 +346,67 @@ where
     /// Get an immutable reference to the current state of the state machine.
     pub fn state(&self) -> &M::State {
         &self.inner.state
+    }
+
+    /// Get a reference to the [InitializedStateMachine]'s [Inner] storage.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    /// let initialized_state_machine = uninitialized_state_machine.init();
+    /// assert_eq!(initialized_state_machine.inner().shared_storage.led, false);
+    /// assert_eq!(initialized_state_machine.inner().state, State::on());
+    /// ```
+    pub fn inner(&self) -> &Inner<M> {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the [InitializedStateMachine]'s [Inner] storage.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [InitializedStateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    /// let mut initialized_state_machine = uninitialized_state_machine.init();
+    /// unsafe {
+    ///     initialized_state_machine.inner_mut().shared_storage.led = true;
+    /// }
+    /// ```
+    pub unsafe fn inner_mut(&mut self) -> &mut Inner<M> {
+        &mut self.inner
     }
 }
 
@@ -457,6 +579,61 @@ where
         let mut state_machine = InitializedStateMachine { inner: self.inner };
         state_machine.inner.async_init_with_context(context).await;
         state_machine
+    }
+
+    /// Get a reference to the [UninitializedStateMachine]'s [Inner] storage.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    ///
+    /// assert_eq!(uninitialized_state_machine.inner().shared_storage.led, false);
+    /// assert_eq!(uninitialized_state_machine.inner().state, State::on());
+    /// ```
+    pub fn inner(&self) -> &Inner<M> {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the [UninitializedStateMachine]'s [Inner] storage.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    ///
+    /// uninitialized_state_machine.inner_mut().shared_storage.led = true;
+    /// uninitialized_state_machine.inner_mut().state = State::on();
+    /// ```
+    pub fn inner_mut(&mut self) -> &mut Inner<M> {
+        &mut self.inner
     }
 }
 

--- a/statig/src/blocking/mod.rs
+++ b/statig/src/blocking/mod.rs
@@ -7,6 +7,7 @@ mod superstate;
 pub use crate::Response::{self, *};
 pub use crate::*;
 
+pub use inner::*;
 pub use state::*;
 pub use state_machine::*;
 pub use superstate::*;

--- a/statig/src/blocking/state_machine.rs
+++ b/statig/src/blocking/state_machine.rs
@@ -111,6 +111,67 @@ where
     pub fn state(&self) -> &M::State {
         &self.inner.state
     }
+
+    /// Get a reference to the [StateMachine]'s [Inner] storage.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let state_machine = Blinky::default().state_machine();
+    /// assert_eq!(state_machine.inner().shared_storage.led, false);
+    /// assert_eq!(state_machine.inner().state, State::on());
+    /// ```
+    pub fn inner(&self) -> &Inner<M> {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the [StateMachine]'s [Inner] storage.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [StateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut state_machine = Blinky::default().state_machine();
+    ///
+    /// unsafe {
+    ///     state_machine.inner_mut().shared_storage.led = true;
+    ///     state_machine.inner_mut().state = State::on();
+    /// }
+    /// ```
+    pub unsafe fn inner_mut(&mut self) -> &mut Inner<M> {
+        &mut self.inner
+    }
 }
 
 impl<M> Clone for StateMachine<M>
@@ -264,6 +325,67 @@ where
     /// Get an immutable reference to the current state of the state machine.
     pub fn state(&self) -> &M::State {
         &self.inner.state
+    }
+
+    /// Get a reference to the [InitializedStateMachine]'s [Inner] storage.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    /// let initialized_state_machine = uninitialized_state_machine.init();
+    /// assert_eq!(initialized_state_machine.inner().shared_storage.led, false);
+    /// assert_eq!(initialized_state_machine.inner().state, State::on());
+    /// ```
+    pub fn inner(&self) -> &Inner<M> {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the [InitializedStateMachine]'s [Inner] storage.
+    /// 
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [InitializedStateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    /// let mut initialized_state_machine = uninitialized_state_machine.init();
+    /// unsafe {
+    ///     initialized_state_machine.inner_mut().shared_storage.led = true;
+    /// }
+    /// ```
+    pub unsafe fn inner_mut(&mut self) -> &mut Inner<M> {
+        &mut self.inner
     }
 }
 
@@ -433,6 +555,61 @@ where
         let mut state_machine = InitializedStateMachine { inner: self.inner };
         state_machine.inner.init_with_context(context);
         state_machine
+    }
+
+    /// Get a reference to the [UninitializedStateMachine]'s [Inner] storage.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    ///
+    /// assert_eq!(uninitialized_state_machine.inner().shared_storage.led, false);
+    /// assert_eq!(uninitialized_state_machine.inner().state, State::on());
+    /// ```
+    pub fn inner(&self) -> &Inner<M> {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the [UninitializedStateMachine]'s [Inner] storage.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    ///
+    /// uninitialized_state_machine.inner_mut().shared_storage.led = true;
+    /// uninitialized_state_machine.inner_mut().state = State::on();
+    /// ```
+    pub fn inner_mut(&mut self) -> &mut Inner<M> {
+        &mut self.inner
     }
 }
 

--- a/statig/src/inner.rs
+++ b/statig/src/inner.rs
@@ -3,8 +3,8 @@ use crate::awaitable::{self, StateExt as _};
 use crate::blocking::{self, StateExt as _};
 use crate::{IntoStateMachine, Response};
 
-/// Private internal representation of a state machine that is used for the public types.
-pub(crate) struct Inner<M>
+/// Internal representation of a state machine that is used for the public types.
+pub struct Inner<M>
 where
     M: IntoStateMachine,
 {

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(doctest), doc = include_str!("../../README.md"))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(doc)), no_std)]
 #![allow(incomplete_features)]
 
 mod inner;
@@ -143,7 +143,7 @@ pub use statig_macro::action;
 
 /// Prelude containing the necessary imports for use with macro.
 pub mod prelude {
-    #[cfg(feature = "async")]
+    #[cfg(any(feature = "async", doc))]
     pub use crate::awaitable::{IntoStateMachineExt as _, StateExt as _, *};
     pub use crate::blocking::{IntoStateMachineExt as _, StateExt as _, *};
     pub use crate::Response::{self, *};
@@ -154,7 +154,7 @@ pub mod prelude {
 
 pub mod blocking;
 
-#[cfg(feature = "async")]
+#[cfg(any(feature = "async", doc))]
 pub mod awaitable;
 
 pub(crate) use inner::*;


### PR DESCRIPTION
Problem: Mutable access to `Inner` is required for ergonomic unit testing.

Solution: Add `inner` and `inner_mut` to:
- `awaitable::state_machine{UninitializedStateMachine, InitializedStateMachine}`
- `blocking::state_machine{UninitializedStateMachine, InitializedStateMachine}` Mark the methods as `unsafe` for the case of an
`InitializedStateMachine` to force users to think critically about mutating in thise case.

Testing: `cargo test`

Issue: https://github.com/mdeloof/statig/issues/34