### PR TITLE
feat: expose references to `shared_storage`

### DIFF
--- a/statig/src/awaitable/state_machine.rs
+++ b/statig/src/awaitable/state_machine.rs
@@ -129,6 +129,97 @@ where
     pub fn state(&self) -> &M::State {
         &self.inner.state
     }
+
+    /// Get a reference to the [StateMachine]'s underlying type.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let state_machine = Blinky::default().state_machine();
+    /// assert_eq!(state_machine.inner().led, false);
+    /// ```
+    pub fn inner(&self) -> &M {
+        &self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [StateMachine]'s underlying type.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [StateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut state_machine = Blinky::default().state_machine();
+    ///
+    /// unsafe {
+    ///     state_machine.inner_mut().led = true;
+    /// }
+    /// ```
+    pub unsafe fn inner_mut(&mut self) -> &mut M {
+        &mut self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [StateMachine]'s current state.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [StateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut state_machine = Blinky::default().state_machine();
+    ///
+    /// unsafe {
+    ///     *state_machine.state_mut() = State::on();
+    /// }
+    /// ```
+    pub unsafe fn state_mut(&mut self) -> &mut M::State {
+        &mut self.inner.state
+    }
 }
 
 impl<M> Clone for StateMachine<M>
@@ -285,6 +376,99 @@ where
     /// Get an immutable reference to the current state of the state machine.
     pub fn state(&self) -> &M::State {
         &self.inner.state
+    }
+
+    /// Get a reference to the [InitializedStateMachine]'s underlying type.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    /// let initialized_state_machine = uninitialized_state_machine.init();
+    /// assert_eq!(initialized_state_machine.inner().led, false);
+    /// ```
+    pub fn inner(&self) -> &M {
+        &self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [InitializedStateMachine]'s underlying type.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [InitializedStateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    /// let mut initialized_state_machine = uninitialized_state_machine.init();
+    /// unsafe {
+    ///     initialized_state_machine.inner_mut().led = true;
+    /// }
+    /// ```
+    pub unsafe fn inner_mut(&mut self) -> &mut M {
+        &mut self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [InitializedStateMachine]'s current state.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [StateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    /// let mut initialized_state_machine = uninitialized_state_machine.init();
+    ///
+    /// unsafe {
+    ///     *initialized_state_machine.state_mut() = State::on();
+    /// }
+    /// ```
+    pub unsafe fn state_mut(&mut self) -> &mut M::State {
+        &mut self.inner.state
     }
 }
 
@@ -457,6 +641,89 @@ where
         let mut state_machine = InitializedStateMachine { inner: self.inner };
         state_machine.inner.async_init_with_context(context).await;
         state_machine
+    }
+
+    /// Get a reference to the [UninitializedStateMachine]'s underlying type.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    ///
+    /// assert_eq!(uninitialized_state_machine.inner().led, false);
+    /// ```
+    pub fn inner(&self) -> &M {
+        &self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [UninitializedStateMachine]'s underlying type.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    ///
+    /// uninitialized_state_machine.inner_mut().led = true;
+    /// ```
+    pub fn inner_mut(&mut self) -> &mut M {
+        &mut self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [StateMachine]'s current state.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [StateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    ///
+    /// *uninitialized_state_machine.state_mut() = State::on();
+    /// ```
+    pub fn state_mut(&mut self) -> &mut M::State {
+        &mut self.inner.state
     }
 }
 

--- a/statig/src/blocking/state_machine.rs
+++ b/statig/src/blocking/state_machine.rs
@@ -111,6 +111,97 @@ where
     pub fn state(&self) -> &M::State {
         &self.inner.state
     }
+
+    /// Get a reference to the [StateMachine]'s underlying type.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let state_machine = Blinky::default().state_machine();
+    /// assert_eq!(state_machine.inner().led, false);
+    /// ```
+    pub fn inner(&self) -> &M {
+        &self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [StateMachine]'s underlying type.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [StateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut state_machine = Blinky::default().state_machine();
+    ///
+    /// unsafe {
+    ///     state_machine.inner_mut().led = true;
+    /// }
+    /// ```
+    pub unsafe fn inner_mut(&mut self) -> &mut M {
+        &mut self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [StateMachine]'s current state.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [StateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut state_machine = Blinky::default().state_machine();
+    ///
+    /// unsafe {
+    ///     *state_machine.state_mut() = State::on();
+    /// }
+    /// ```
+    pub unsafe fn state_mut(&mut self) -> &mut M::State {
+        &mut self.inner.state
+    }
 }
 
 impl<M> Clone for StateMachine<M>
@@ -264,6 +355,99 @@ where
     /// Get an immutable reference to the current state of the state machine.
     pub fn state(&self) -> &M::State {
         &self.inner.state
+    }
+
+    /// Get a reference to the [InitializedStateMachine]'s underlying type.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    /// let initialized_state_machine = uninitialized_state_machine.init();
+    /// assert_eq!(initialized_state_machine.inner().led, false);
+    /// ```
+    pub fn inner(&self) -> &M {
+        &self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [InitializedStateMachine]'s underlying type.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [InitializedStateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    /// let mut initialized_state_machine = uninitialized_state_machine.init();
+    /// unsafe {
+    ///     initialized_state_machine.inner_mut().led = true;
+    /// }
+    /// ```
+    pub unsafe fn inner_mut(&mut self) -> &mut M {
+        &mut self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [InitializedStateMachine]'s current state.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [StateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    /// let mut initialized_state_machine = uninitialized_state_machine.init();
+    ///
+    /// unsafe {
+    ///     *initialized_state_machine.state_mut() = State::on();
+    /// }
+    /// ```
+    pub unsafe fn state_mut(&mut self) -> &mut M::State {
+        &mut self.inner.state
     }
 }
 
@@ -433,6 +617,89 @@ where
         let mut state_machine = InitializedStateMachine { inner: self.inner };
         state_machine.inner.init_with_context(context);
         state_machine
+    }
+
+    /// Get a reference to the [UninitializedStateMachine]'s underlying type.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(
+    /// #     initial = "State::on()",
+    /// #     state(derive(Debug, PartialEq, Eq))
+    /// # )]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    ///
+    /// assert_eq!(uninitialized_state_machine.inner().led, false);
+    /// ```
+    pub fn inner(&self) -> &M {
+        &self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [UninitializedStateMachine]'s underlying type.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    ///
+    /// uninitialized_state_machine.inner_mut().led = true;
+    /// ```
+    pub fn inner_mut(&mut self) -> &mut M {
+        &mut self.inner.shared_storage
+    }
+
+    /// Get a mutable reference to the [StateMachine]'s current state.
+    ///
+    /// # Safety
+    ///
+    /// - The user is responsible for validating that mutating a
+    ///   [StateMachine] does not break any invariants.
+    ///
+    /// ```
+    /// # use statig::prelude::*;
+    /// # #[derive(Default)]
+    /// # pub struct Blinky {
+    /// #     led: bool,
+    /// # }
+    /// #
+    /// # pub struct Event;
+    /// #
+    /// # #[state_machine(initial = "State::on()")]
+    /// # impl Blinky {
+    /// #     #[state]
+    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// # }
+    /// #
+    /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
+    ///
+    /// *uninitialized_state_machine.state_mut() = State::on();
+    /// ```
+    pub fn state_mut(&mut self) -> &mut M::State {
+        &mut self.inner.state
     }
 }
 

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(doctest), doc = include_str!("../../README.md"))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(doc)), no_std)]
 #![allow(incomplete_features)]
 
 mod inner;
@@ -143,7 +143,7 @@ pub use statig_macro::action;
 
 /// Prelude containing the necessary imports for use with macro.
 pub mod prelude {
-    #[cfg(feature = "async")]
+    #[cfg(any(feature = "async", doc))]
     pub use crate::awaitable::{IntoStateMachineExt as _, StateExt as _, *};
     pub use crate::blocking::{IntoStateMachineExt as _, StateExt as _, *};
     pub use crate::Response::{self, *};
@@ -154,7 +154,7 @@ pub mod prelude {
 
 pub mod blocking;
 
-#[cfg(feature = "async")]
+#[cfg(any(feature = "async", doc))]
 pub mod awaitable;
 
 pub(crate) use inner::*;


### PR DESCRIPTION
Problem: Mutable access to `shared_storage` and `state` is required for
ergonomic unit testing.

Solution: Add `inner`, `inner_mut`, and `staet_mut` to:
- `awaitable::state_machine{StateMachine, UninitializedStateMachine,
  InitializedStateMachine}`
- `blocking::state_machine{StateMachine, UninitializedStateMachine,
  InitializedStateMachine}`
Mark `inner_mut` and `state_mut` as `unsafe` for the case of an
`InitializedStateMachine` and `StateMachine` to force users to think
critically about mutating in thise case.

Testing: `cargo test`

Issue: https://github.com/mdeloof/statig/issues/34
