### PR TITLE
feat: permit custom state types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "examples/no_macro/bench",
     "examples/no_macro/history",
     "examples/no_macro/calculator",
+    "examples/macro/custom_state",
 ]
 
 resolver = "2"

--- a/examples/macro/custom_state/Cargo.toml
+++ b/examples/macro/custom_state/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "custom_state"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+statig = { path = "../../../statig" }

--- a/examples/macro/custom_state/src/main.rs
+++ b/examples/macro/custom_state/src/main.rs
@@ -1,0 +1,99 @@
+#![allow(unused)]
+
+use statig::prelude::*;
+use std::fmt::Debug;
+use std::io::Write;
+
+#[derive(Debug, Default)]
+pub struct Blinky;
+
+// The event that will be handled by the state machine.
+#[derive(Debug)]
+pub enum Event {
+    TimerElapsed,
+    ButtonPressed,
+}
+
+pub enum CustomState {
+    NotBlinking,
+    LedOff,
+    LedOn,
+}
+
+impl CustomState {
+    pub const fn led_on() -> Self {
+        Self::LedOn
+    }
+}
+
+/// The `state_machine` procedural macro generates the `State` and `Superstate`
+/// enums by parsing the function signatures with a `state`, `superstate` or
+/// `action` attribute. It also implements the `statig::State` and
+/// `statig::Superstate` traits.
+#[state_machine(
+    // This sets the initial state to `led_on`.
+    initial = "CustomState::led_on()",
+    // Derive the Debug trait on the `State` enum.
+    state(derive(Debug)),
+    // Derive the Debug trait on the `Superstate` enum.
+    superstate(derive(Debug)),
+    // Adding custom tells the macro not to generate a State type and to
+    // instead use the name field to map to a local type.
+    state(custom, name = "CustomState")
+)]
+impl Blinky {
+    /// The `#[state]` attibute marks this as a state handler.  By default the
+    /// `event` argument will map to the event handler by the state machine.
+    /// Every state must return a `Response<CustomState>`.
+    #[state(superstate = "blinking")]
+    fn led_on(event: &Event) -> Response<CustomState> {
+        match event {
+            // When we receive a `TimerElapsed` event we transition to the `led_off` state.
+            Event::TimerElapsed => Transition(CustomState::LedOff),
+            // Other events are deferred to the superstate, in this case `blinking`.
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "blinking")]
+    fn led_off(event: &Event) -> Response<CustomState> {
+        match event {
+            Event::TimerElapsed => Transition(CustomState::LedOn),
+            _ => Super,
+        }
+    }
+
+    /// The `#[superstate]` attribute marks this as a superstate handler.
+    #[superstate]
+    fn blinking(event: &Event) -> Response<CustomState> {
+        match event {
+            Event::ButtonPressed => Transition(CustomState::NotBlinking),
+            _ => Super,
+        }
+    }
+
+    #[state]
+    fn not_blinking(event: &Event) -> Response<CustomState> {
+        match event {
+            Event::ButtonPressed => Transition(CustomState::LedOn),
+            // Altough this state has no superstate, we can still defer the event which
+            // will cause the event to be handled by an implicit `top` superstate.
+            _ => Super,
+        }
+    }
+}
+
+fn main() {
+    let start = std::time::Instant::now();
+
+    let mut state_machine = Blinky::default().state_machine();
+
+    state_machine.handle(&Event::TimerElapsed);
+    state_machine.handle(&Event::ButtonPressed);
+    state_machine.handle(&Event::TimerElapsed);
+    state_machine.handle(&Event::ButtonPressed);
+
+    let end = std::time::Instant::now();
+
+    println!("Duration: {:?}", end - start);
+}

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -23,3 +23,6 @@ syn = { version = "2", features = [
 quote = "1.0.23"
 proc-macro2 = { version = "1.0.91", default-features = false }
 proc-macro-error2 = { version = "2.0.1", features = ["syn-error"] }
+
+[dev-dependencies]
+trybuild = "1.0.90"

--- a/statig/Cargo.toml
+++ b/statig/Cargo.toml
@@ -22,6 +22,7 @@ futures = { version = "0.3.26" }
 serde_json = "1.0.91"
 serde = { version = "1.0.152", features = ["derive"] }
 unit-enum = { git = "https://github.com/mdeloof/unit-enum.git" }
+trybuild = "1.0.90"
 
 [features]
 default = ["macro"]

--- a/statig/tests/ui/custom_state.rs
+++ b/statig/tests/ui/custom_state.rs
@@ -1,0 +1,61 @@
+#![allow(unused_variables, dead_code, ambiguous_glob_reexports)]
+
+use statig::prelude::*;
+
+#[derive(Default)]
+pub struct Blinky {}
+
+pub enum Event {
+    TimerElapsed,
+    ButtonPressed,
+}
+
+pub enum CustomState {
+    LedOn,
+    LedOff,
+}
+
+impl CustomState {
+    pub const fn led_on() -> Self {
+        Self::LedOn
+    }
+    pub const fn led_off() -> Self {
+        Self::LedOff
+    }
+}
+
+#[state_machine(
+    // This sets the initial state to `led_on`.
+    initial = "CustomState::led_on()",
+    // Derive the Debug trait on the `Superstate` enum.
+    superstate(derive(Debug)),
+    // Adding custom tells the macro not to generate a State type and to
+    // instead use the name field to map to a local type.
+    state(custom, name = "CustomState")
+)]
+impl Blinky {
+    #[state]
+    fn led_on(event: &Event) -> Response<CustomState> {
+        Transition(CustomState::led_off())
+    }
+
+    #[state]
+    fn led_off(event: &Event) -> Response<CustomState> {
+        Transition(CustomState::led_on())
+    }
+}
+
+fn main() {
+    let start = std::time::Instant::now();
+
+    let mut state_machine = Blinky::default().state_machine();
+
+    state_machine.handle(&Event::TimerElapsed);
+    state_machine.handle(&Event::ButtonPressed);
+    state_machine.handle(&Event::TimerElapsed);
+    state_machine.handle(&Event::ButtonPressed);
+
+    let end = std::time::Instant::now();
+
+    println!("Duration: {:?}", end - start);
+}

--- a/statig/tests/ui/custom_state_derive_error.rs
+++ b/statig/tests/ui/custom_state_derive_error.rs
@@ -1,0 +1,61 @@
+#![allow(unused_variables, dead_code, ambiguous_glob_reexports)]
+
+use statig::prelude::*;
+
+#[derive(Default)]
+pub struct Blinky {}
+
+pub enum Event {
+    TimerElapsed,
+    ButtonPressed,
+}
+
+pub enum CustomState {
+    LedOn,
+    LedOff,
+}
+
+impl CustomState {
+    pub const fn led_on() -> Self {
+        Self::LedOn
+    }
+    pub const fn led_off() -> Self {
+        Self::LedOff
+    }
+}
+
+#[state_machine(
+    // This sets the initial state to `led_on`.
+    initial = "CustomState::led_on()",
+    // Derive the Debug trait on the `Superstate` enum.
+    superstate(derive(Debug)),
+    // Adding custom tells the macro not to generate a State type and to
+    // instead use the name field to map to a local type.
+    state(custom, name = "CustomState", derive(Debug))
+)]
+impl Blinky {
+    #[state]
+    fn led_on(event: &Event) -> Response<CustomState> {
+        Transition(CustomState::led_off())
+    }
+
+    #[state]
+    fn led_off(event: &Event) -> Response<CustomState> {
+        Transition(CustomState::led_on())
+    }
+}
+
+fn main() {
+    let start = std::time::Instant::now();
+
+    let mut state_machine = Blinky::default().state_machine();
+
+    state_machine.handle(&Event::TimerElapsed);
+    state_machine.handle(&Event::ButtonPressed);
+    state_machine.handle(&Event::TimerElapsed);
+    state_machine.handle(&Event::ButtonPressed);
+
+    let end = std::time::Instant::now();
+
+    println!("Duration: {:?}", end - start);
+}

--- a/statig/tests/ui/custom_state_derive_error.stderr
+++ b/statig/tests/ui/custom_state_derive_error.stderr
@@ -1,0 +1,42 @@
+error: Can not use `custom` with derives
+  --> tests/ui/custom_state_derive_error.rs:34:11
+   |
+34 |     state(custom, name = "CustomState", derive(Debug))
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0599]: the method `state_machine` exists for struct `Blinky`, but its trait bounds were not satisfied
+  --> tests/ui/custom_state_derive_error.rs:51:47
+   |
+6  | pub struct Blinky {}
+   | ----------------- method `state_machine` not found for this struct because it doesn't satisfy `Blinky: statig::awaitable::IntoStateMachineExt`, `Blinky: statig::awaitable::IntoStateMachine`, `Blinky: statig::blocking::IntoStateMachineExt` or `Blinky: statig::blocking::IntoStateMachine`
+...
+51 |     let mut state_machine = Blinky::default().state_machine();
+   |                                               ^^^^^^^^^^^^^ method cannot be called on `Blinky` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `Blinky: statig::awaitable::IntoStateMachine`
+           which is required by `Blinky: statig::awaitable::IntoStateMachineExt`
+           `Blinky: statig::blocking::IntoStateMachine`
+           which is required by `Blinky: statig::blocking::IntoStateMachineExt`
+           `&Blinky: statig::awaitable::IntoStateMachine`
+           which is required by `&Blinky: statig::awaitable::IntoStateMachineExt`
+           `&Blinky: statig::blocking::IntoStateMachine`
+           which is required by `&Blinky: statig::blocking::IntoStateMachineExt`
+           `&mut Blinky: statig::awaitable::IntoStateMachine`
+           which is required by `&mut Blinky: statig::awaitable::IntoStateMachineExt`
+           `&mut Blinky: statig::blocking::IntoStateMachine`
+           which is required by `&mut Blinky: statig::blocking::IntoStateMachineExt`
+note: the traits `statig::awaitable::IntoStateMachine` and `statig::blocking::IntoStateMachine` must be implemented
+  --> src/awaitable/into_state_machine.rs
+   |
+   | pub trait IntoStateMachine
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+  ::: src/blocking/into_state_machine.rs
+   |
+   | pub trait IntoStateMachine
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following traits define an item `state_machine`, perhaps you need to implement one of them:
+           candidate #1: `statig::awaitable::IntoStateMachineExt`
+           candidate #2: `statig::blocking::IntoStateMachineExt`

--- a/statig/tests/ui_tests.rs
+++ b/statig/tests/ui_tests.rs
@@ -1,0 +1,6 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/custom_state.rs");
+    t.compile_fail("tests/ui/custom_state_derive_error.rs");
+}


### PR DESCRIPTION
Problem: Currently, the macro does not support user-defined state enums. This limitation is particularly noticeable when users require fine-grained control over Serde serialization/deserialization, specifically when needing to leverage attributes like `skip` and `default`.

Solution: Support a `custom_state` attribute. Permit users to define their own external state type that will be used. Skip generating enum and constructor definitions in this event.

Testing: Implemented an example and added UI test cases.

Issue: https://github.com/mdeloof/statig/issues/43