### PR TITLE
Add default attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ impl IntoStateMachine for Blinky {
 
     type Context<'ctx> = Context;
 
-    const INITIAL: State = State::off(10);
+    const INITIAL: fn() -> State = || State::off(10);
 }
 ```
 

--- a/examples/macro/barrier/src/main.rs
+++ b/examples/macro/barrier/src/main.rs
@@ -11,8 +11,13 @@ enum Event {
 
 #[state_machine(initial = "State::initializing()", state(derive(PartialEq, Eq, Debug)))]
 impl Foo {
-    #[state(superstate = "waiting_for_initialization", default("a", "b", "c"))]
-    fn initializing(a: &mut bool, b: &mut bool, c: &mut bool, event: &Event) -> Response<State> {
+    #[state(superstate = "waiting_for_initialization")]
+    fn initializing(
+        #[default] a: &mut bool,
+        #[default] b: &mut bool,
+        #[default] c: &mut bool,
+        event: &Event,
+    ) -> Response<State> {
         match event {
             Event::A => {
                 *a = true;

--- a/examples/macro/barrier/src/main.rs
+++ b/examples/macro/barrier/src/main.rs
@@ -9,12 +9,9 @@ enum Event {
     C,
 }
 
-#[state_machine(
-    initial = "State::initializing(false, false, false)",
-    state(derive(PartialEq, Eq, Debug))
-)]
+#[state_machine(initial = "State::initializing()", state(derive(PartialEq, Eq, Debug)))]
 impl Foo {
-    #[state(superstate = "waiting_for_initialization")]
+    #[state(superstate = "waiting_for_initialization", default("a", "b", "c"))]
     fn initializing(a: &mut bool, b: &mut bool, c: &mut bool, event: &Event) -> Response<State> {
         match event {
             Event::A => {

--- a/examples/macro/barrier/src/main.rs
+++ b/examples/macro/barrier/src/main.rs
@@ -13,7 +13,7 @@ enum Event {
 impl Foo {
     #[state(superstate = "waiting_for_initialization")]
     fn initializing(
-        #[default] a: &mut bool,
+        #[default = "true"] a: &mut bool,
         #[default] b: &mut bool,
         #[default] c: &mut bool,
         event: &Event,
@@ -50,6 +50,8 @@ impl Foo {
 
 fn main() {
     let mut state_machine = Foo::default().uninitialized_state_machine().init();
+
+    dbg!(state_machine.state());
 
     state_machine.handle(&Event::A);
     state_machine.handle(&Event::B);

--- a/examples/macro/history/src/main.rs
+++ b/examples/macro/history/src/main.rs
@@ -79,7 +79,7 @@ impl Dishwasher {
 
 fn main() {
     let mut state_machine = Dishwasher {
-        previous_state: Dishwasher::INITIAL,
+        previous_state: Dishwasher::INITIAL(),
     }
     .uninitialized_state_machine()
     .init();

--- a/examples/no_macro/basic/src/main.rs
+++ b/examples/no_macro/basic/src/main.rs
@@ -30,7 +30,7 @@ impl IntoStateMachine for Blinky {
     type Context<'ctx> = ();
 
     /// The initial state of the state machine.
-    const INITIAL: State = State::Off;
+    const INITIAL: fn() -> Self::State = || State::Off;
 
     /// This method is called on every transition of the state machine.
     const AFTER_TRANSITION: fn(&mut Self, &Self::State, &Self::State) = |_, source, target| {

--- a/examples/no_macro/bench/src/main.rs
+++ b/examples/no_macro/bench/src/main.rs
@@ -49,7 +49,7 @@ impl IntoStateMachine for CdPlayer {
     type Context<'ctx> = ();
 
     /// The initial state of the state machine.
-    const INITIAL: State = State::Empty;
+    const INITIAL: fn() -> Self::State = || State::Empty;
 }
 
 impl blocking::State<CdPlayer> for State {

--- a/examples/no_macro/blinky/src/main.rs
+++ b/examples/no_macro/blinky/src/main.rs
@@ -41,7 +41,7 @@ impl IntoStateMachine for Blinky {
     type Context<'ctx> = ();
 
     /// The initial state of the state machine.
-    const INITIAL: State = State::LedOn;
+    const INITIAL: fn() -> Self::State = || State::LedOn;
 }
 
 // Implement the `statig::State` trait for the state enum.

--- a/examples/no_macro/calculator/src/state.rs
+++ b/examples/no_macro/calculator/src/state.rs
@@ -66,7 +66,7 @@ impl blocking::IntoStateMachine for Calculator {
 
     type Context<'ctx> = ();
 
-    const INITIAL: State = State::Begin;
+    const INITIAL: fn() -> Self::State = || State::Begin;
 }
 
 impl blocking::State<Calculator> for State {

--- a/examples/no_macro/history/src/main.rs
+++ b/examples/no_macro/history/src/main.rs
@@ -36,7 +36,7 @@ impl IntoStateMachine for Dishwasher {
 
     type Context<'ctx> = ();
 
-    const INITIAL: State = State::Idle;
+    const INITIAL: fn() -> Self::State = || State::Idle;
 
     // On every transition we update the previous state, so we can
     // transition back to it.
@@ -135,7 +135,7 @@ impl Dishwasher {
 
 fn main() {
     let mut state_machine = Dishwasher {
-        previous_state: Dishwasher::INITIAL,
+        previous_state: Dishwasher::INITIAL(),
     }
     .uninitialized_state_machine()
     .init();

--- a/macro/src/analyze.rs
+++ b/macro/src/analyze.rs
@@ -469,13 +469,6 @@ pub fn analyze_state(method: &mut ImplItemMethod, state_machine: &StateMachine) 
                     }
                 }
             }
-            Meta::List(list) if list.path.is_ident("default") => {
-                for item in list.nested {
-                    if let NestedMeta::Lit(Lit::Str(value)) = item {
-                        local_storage_default.push(Ident::new(&value.value(), value.span()));
-                    }
-                }
-            }
             _ => abort!(meta, "unknown attribute"),
         }
     }

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -93,7 +93,7 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
             type Context<#context_lifetime> = #context_type;
             type State = #state_ident #state_generics;
             type Superstate<#superstate_lifetime> = #superstate_ident #superstate_generics ;
-            const INITIAL: #state_ident #state_generics = #initial_state;
+            const INITIAL: fn() -> Self::State = #initial_state;
 
             #before_transition
             #after_transition

--- a/statig/src/awaitable/state_machine.rs
+++ b/statig/src/awaitable/state_machine.rs
@@ -17,7 +17,7 @@ where
     {
         let inner = Inner {
             shared_storage: self,
-            state: Self::INITIAL,
+            state: Self::INITIAL(),
         };
         StateMachine {
             inner,
@@ -30,7 +30,7 @@ where
     fn uninitialized_state_machine(self) -> UninitializedStateMachine<Self> {
         let inner = Inner {
             shared_storage: self,
-            state: Self::INITIAL,
+            state: Self::INITIAL(),
         };
         UninitializedStateMachine { inner }
     }
@@ -167,7 +167,7 @@ where
     fn default() -> Self {
         let inner = Inner {
             shared_storage: M::default(),
-            state: M::INITIAL,
+            state: M::INITIAL(),
         };
         Self {
             inner,

--- a/statig/src/blocking/state_machine.rs
+++ b/statig/src/blocking/state_machine.rs
@@ -15,7 +15,7 @@ where
     {
         let inner = Inner {
             shared_storage: self,
-            state: Self::INITIAL,
+            state: Self::INITIAL(),
         };
         StateMachine {
             inner,
@@ -28,7 +28,7 @@ where
     fn uninitialized_state_machine(self) -> UninitializedStateMachine<Self> {
         let inner = Inner {
             shared_storage: self,
-            state: Self::INITIAL,
+            state: Self::INITIAL(),
         };
         UninitializedStateMachine { inner }
     }
@@ -149,7 +149,7 @@ where
     fn default() -> Self {
         let inner = Inner {
             shared_storage: M::default(),
-            state: M::INITIAL,
+            state: M::INITIAL(),
         };
         Self {
             inner,

--- a/statig/src/into_state_machine.rs
+++ b/statig/src/into_state_machine.rs
@@ -20,7 +20,7 @@ where
         Self::State: 'sub;
 
     /// Initial state of the state machine.
-    const INITIAL: Self::State;
+    const INITIAL: fn() -> Self::State;
 
     /// Method that is called *before* an event is dispatched to a state or
     /// superstate handler.

--- a/statig/tests/async_transition.rs
+++ b/statig/tests/async_transition.rs
@@ -57,7 +57,7 @@ mod tests {
 
         type Context<'ctx> = ();
 
-        const INITIAL: State = State::S11;
+        const INITIAL: fn() -> Self::State = || State::S11;
     }
 
     impl awaitable::State<Foo> for State {

--- a/statig/tests/default.rs
+++ b/statig/tests/default.rs
@@ -1,0 +1,14 @@
+#[cfg(test)]
+mod tests {
+    use statig::blocking::*;
+
+    pub struct Foo;
+
+    #[state_machine(initial = "State::bar()")]
+    impl Foo {
+        #[state]
+        fn bar(#[default] _local: &mut usize) -> Response<State> {
+            Handled
+        }
+    }
+}

--- a/statig/tests/default.rs
+++ b/statig/tests/default.rs
@@ -7,7 +7,10 @@ mod tests {
     #[state_machine(initial = "State::bar()")]
     impl Foo {
         #[state]
-        fn bar(#[default] _local: &mut usize) -> Response<State> {
+        fn bar(
+            #[default] _local: &mut usize,
+            #[default = "100"] _local_2: &mut usize,
+        ) -> Response<State> {
             Handled
         }
     }

--- a/statig/tests/state_local_storage.rs
+++ b/statig/tests/state_local_storage.rs
@@ -24,7 +24,7 @@ mod tests {
         type Context<'ctx> = ();
 
         /// The initial state of the state machine.
-        const INITIAL: StateEnum = StateEnum::On {
+        const INITIAL: fn() -> Self::State = || StateEnum::On {
             led: false,
             counter: 23,
         };
@@ -32,7 +32,7 @@ mod tests {
 
     impl Default for StateEnum {
         fn default() -> Self {
-            Blinky::INITIAL
+            Blinky::INITIAL()
         }
     }
 

--- a/statig/tests/transition.rs
+++ b/statig/tests/transition.rs
@@ -55,7 +55,7 @@ mod tests {
 
         type Context<'ctx> = ();
 
-        const INITIAL: State = State::S11;
+        const INITIAL: fn() -> Self::State = || State::S11;
     }
 
     impl blocking::State<Foo> for State {


### PR DESCRIPTION
This PR adds the `#[default]` attribute which can be used to set a default value for state-local storage fields.

```rust
#[state_machine(initial = "State::foo()")]
impl MyStateMachine {
    #[state]
    fn foo(#[default] check_1: &mut bool, #[default = "true"] check_2: &mut bool) -> Response<State> {
        ...
    }
}
```