### PR TITLE
Pass context to callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,19 +270,19 @@ impl Blinky {
 }
 
 impl Blinky {
-    fn before_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
+    fn before_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event, _context: &mut ()) {
         println!("before dispatched `{:?}` to `{:?}`", event, state);
     }
 
-    fn after_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event) {
+    fn after_dispatch(&mut self, state: StateOrSuperstate<Blinky>, event: &Event, _context: &mut ()) {
         println!("after dispatched `{:?}` to `{:?}`", event, state);
     }
 
-    fn before_transition(&mut self, source: &State, target: &State) {
+    fn before_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
         println!("before transitioned from `{:?}` to `{:?}`", source, target);
     }
 
-    fn after_transition(&mut self, source: &State, target: &State) {
+    fn after_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
         println!("after transitioned from `{:?}` to `{:?}`", source, target);
     }
 }

--- a/examples/macro/async_blinky/src/main.rs
+++ b/examples/macro/async_blinky/src/main.rs
@@ -83,11 +83,11 @@ impl Blinky {
 
 impl Blinky {
     // The `after_transition` callback that will be called after every transition.
-    async fn after_transition(&mut self, source: &State, target: &State) {
+    async fn after_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
         println!("after transitioned from `{source:?}` to `{target:?}`");
     }
 
-    async fn before_transition(&mut self, source: &State, target: &State) {
+    async fn before_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
         println!("before transitioned from `{source:?}` to `{target:?}`");
     }
 
@@ -95,6 +95,7 @@ impl Blinky {
         &mut self,
         state: StateOrSuperstate<'_, State, Superstate>,
         event: &Event,
+        _context: &mut (),
     ) {
         println!("before dispatching `{event:?}` to `{state:?}`");
     }
@@ -103,6 +104,7 @@ impl Blinky {
         &mut self,
         state: StateOrSuperstate<'_, State, Superstate>,
         event: &Event,
+        _context: &mut (),
     ) {
         println!("after dispatched `{event:?}` to `{state:?}`");
     }

--- a/examples/macro/blinky/src/main.rs
+++ b/examples/macro/blinky/src/main.rs
@@ -74,11 +74,11 @@ impl Blinky {
 
 impl Blinky {
     // The `after_transition` callback that will be called after every transition.
-    fn after_transition(&mut self, source: &State, target: &State) {
+    fn after_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
         println!("transitioned from `{source:?}` to `{target:?}`");
     }
 
-    fn before_dispatch(&mut self, state: StateOrSuperstate<'_, State, Superstate>, event: &Event) {
+    fn before_dispatch(&mut self, state: StateOrSuperstate<'_, State, Superstate>, event: &Event,  _context: &mut ()) {
         println!("dispatching `{event:?}` to `{state:?}`");
     }
 }

--- a/examples/macro/history/src/main.rs
+++ b/examples/macro/history/src/main.rs
@@ -19,7 +19,7 @@ pub struct Dishwasher {
 )]
 impl Dishwasher {
     // On every transition we update the previous state, so we can transition back to it.
-    fn after_transition(&mut self, source: &State, _target: &State) {
+    fn after_transition(&mut self, source: &State, _target: &State, _context: &mut ()) {
         // println!("transitioned from `{:?}` to `{:?}`", source, _target);
         self.previous_state = source.clone();
     }

--- a/examples/no_macro/basic/src/main.rs
+++ b/examples/no_macro/basic/src/main.rs
@@ -35,7 +35,7 @@ impl IntoStateMachine for Blinky {
     }
 
     /// This method is called on every transition of the state machine.
-    fn after_transition(&mut self, source: &Self::State, target: &Self::State) {
+    fn after_transition(&mut self, source: &Self::State, target: &Self::State, _context: &mut ()) {
         println!("transitioned from {source:?} to {target:?}");
     }
 }

--- a/examples/no_macro/history/src/main.rs
+++ b/examples/no_macro/history/src/main.rs
@@ -42,7 +42,7 @@ impl IntoStateMachine for Dishwasher {
 
     // On every transition we update the previous state, so we can
     // transition back to it.
-    fn after_transition(&mut self, source: &Self::State, _target: &Self::State) {
+    fn after_transition(&mut self, source: &Self::State, _target: &Self::State, _context: &mut ()) {
         self.previous_state = source.clone();
     }
 }

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -65,8 +65,9 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     &mut self,
                     state_or_superstate: StateOrSuperstate<'_, Self::State, Self::Superstate<'_>>,
                     event: &Self::Event<'_>,
+                    context: &mut Self::Context<'_>,
                 ) {
-                    #before_dispatch(self, state_or_superstate, event);
+                    #before_dispatch(self, state_or_superstate, event, context);
                 }
             ),
             Mode::Awaitable => quote!(
@@ -74,8 +75,9 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     &mut self,
                     state_or_superstate: StateOrSuperstate<'_, Self::State, Self::Superstate<'_>>,
                     event: &Self::Event<'_>,
+                    context: &mut Self::Context<'_>,
                 ) -> impl core::future::Future<Output = ()> {
-                    #before_dispatch(self, state_or_superstate, event)
+                    #before_dispatch(self, state_or_superstate, event, context)
                 }
             ),
         },
@@ -89,8 +91,9 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     &mut self,
                     state_or_superstate: StateOrSuperstate<'_, Self::State, Self::Superstate<'_>>,
                     event: &Self::Event<'_>,
+                    context: &mut Self::Context<'_>,
                 ) {
-                    #after_dispatch(self, state_or_superstate, event);
+                    #after_dispatch(self, state_or_superstate, event, context);
                 }
             ),
             Mode::Awaitable => quote!(
@@ -98,8 +101,9 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     &mut self,
                     state_or_superstate: StateOrSuperstate<'_, Self::State, Self::Superstate<'_>>,
                     event: &Self::Event<'_>,
+                    context: &mut Self::Context<'_>,
                 ) -> impl core::future::Future<Output = ()> {
-                    #after_dispatch(self, state_or_superstate, event)
+                    #after_dispatch(self, state_or_superstate, event, context)
                 }
             ),
         },
@@ -113,8 +117,9 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     &mut self,
                     source: &Self::State,
                     target: &Self::State,
+                    context: &mut Self::Context<'_>,
                 ) {
-                    #before_transition(self, source, target);
+                    #before_transition(self, source, target, context);
                 }
             ),
             Mode::Awaitable => quote!(
@@ -122,8 +127,9 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     &mut self,
                     source: &Self::State,
                     target: &Self::State,
+                    context: &mut Self::Context<'_>,
                 ) -> impl core::future::Future<Output = ()> {
-                    #before_transition(self, source, target)
+                    #before_transition(self, source, target, context)
                 }
             ),
         },
@@ -137,8 +143,9 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     &mut self,
                     source: &Self::State,
                     target: &Self::State,
+                    context: &mut Self::Context<'_>,
                 ) {
-                    #after_transition(self, source, target);
+                    #after_transition(self, source, target, context);
                 }
             ),
             Mode::Awaitable => quote!(
@@ -146,8 +153,9 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     &mut self,
                     source: &Self::State,
                     target: &Self::State,
+                    context: &mut Self::Context<'_>,
                 ) -> impl core::future::Future<Output = ()> {
-                    #after_transition(self, source, target)
+                    #after_transition(self, source, target, context)
                 }
             ),
         },

--- a/statig/src/awaitable/inner.rs
+++ b/statig/src/awaitable/inner.rs
@@ -41,7 +41,7 @@ where
 
     /// Transition from the current state to the given target state.
     pub(crate) async fn transition(&mut self, mut target: M::State, context: &mut M::Context<'_>) {
-        M::before_transition(&mut self.shared_storage, &self.state, &target).await;
+        M::before_transition(&mut self.shared_storage, &self.state, &target, context).await;
 
         // Get the transition path we need to perform from one state to the next.
         let (exit_levels, enter_levels) = self.state.transition_path(&mut target);
@@ -59,7 +59,7 @@ where
             .enter(&mut self.shared_storage, context, enter_levels)
             .await;
 
-        M::after_transition(&mut self.shared_storage, &target, &self.state).await;
+        M::after_transition(&mut self.shared_storage, &target, &self.state, context).await;
     }
 }
 

--- a/statig/src/awaitable/into_state_machine.rs
+++ b/statig/src/awaitable/into_state_machine.rs
@@ -30,6 +30,7 @@ where
         &mut self,
         _state_or_superstate: StateOrSuperstate<'_, Self::State, Self::Superstate<'_>>,
         _event: &Self::Event<'_>,
+        _context: &mut Self::Context<'_>,
     ) -> impl Future<Output = ()> {
         future::ready(())
     }
@@ -40,6 +41,7 @@ where
         &mut self,
         _state_or_superstate: StateOrSuperstate<'_, Self::State, Self::Superstate<'_>>,
         _event: &Self::Event<'_>,
+        _context: &mut Self::Context<'_>,
     ) -> impl Future<Output = ()> {
         future::ready(())
     }
@@ -49,6 +51,7 @@ where
         &mut self,
         _source: &Self::State,
         _target: &Self::State,
+        _context: &mut Self::Context<'_>,
     ) -> impl Future<Output = ()> {
         future::ready(())
     }
@@ -58,6 +61,7 @@ where
         &mut self,
         _source: &Self::State,
         _target: &Self::State,
+        _context: &mut Self::Context<'_>,
     ) -> impl Future<Output = ()> {
         future::ready(())
     }

--- a/statig/src/awaitable/state.rs
+++ b/statig/src/awaitable/state.rs
@@ -107,11 +107,23 @@ where
         context: &mut M::Context<'_>,
     ) -> impl Future<Output = Response<Self>> {
         async move {
-            M::before_dispatch(shared_storage, StateOrSuperstate::State(self), event).await;
+            M::before_dispatch(
+                shared_storage,
+                StateOrSuperstate::State(self),
+                event,
+                context,
+            )
+            .await;
 
             let response = self.call_handler(shared_storage, event, context).await;
 
-            M::after_dispatch(shared_storage, StateOrSuperstate::State(self), event).await;
+            M::after_dispatch(
+                shared_storage,
+                StateOrSuperstate::State(self),
+                event,
+                context,
+            )
+            .await;
 
             match response {
                 Response::Handled => Response::Handled,
@@ -121,6 +133,7 @@ where
                             shared_storage,
                             StateOrSuperstate::Superstate(&superstate),
                             event,
+                            context,
                         )
                         .await;
 
@@ -132,6 +145,7 @@ where
                             shared_storage,
                             StateOrSuperstate::Superstate(&superstate),
                             event,
+                            context,
                         )
                         .await;
 

--- a/statig/src/blocking/inner.rs
+++ b/statig/src/blocking/inner.rs
@@ -39,7 +39,7 @@ where
 
     /// Transition from the current state to the given target state.
     pub(crate) fn transition(&mut self, mut target: M::State, context: &mut M::Context<'_>) {
-        M::before_transition(&mut self.shared_storage, &target, &self.state);
+        M::before_transition(&mut self.shared_storage, &target, &self.state, context);
 
         // Get the transition path we need to perform from one state to the next.
         let (exit_levels, enter_levels) = self.state.transition_path(&mut target);
@@ -55,7 +55,7 @@ where
         self.state
             .enter(&mut self.shared_storage, context, enter_levels);
 
-        M::after_transition(&mut self.shared_storage, &target, &self.state);
+        M::after_transition(&mut self.shared_storage, &target, &self.state, context);
     }
 }
 

--- a/statig/src/blocking/into_state_machine.rs
+++ b/statig/src/blocking/into_state_machine.rs
@@ -28,6 +28,7 @@ where
         &mut self,
         _state_or_superstate: StateOrSuperstate<'_, Self::State, Self::Superstate<'_>>,
         _event: &Self::Event<'_>,
+        _context: &mut Self::Context<'_>,
     ) {
     }
 
@@ -37,12 +38,25 @@ where
         &mut self,
         _state_or_superstate: StateOrSuperstate<'_, Self::State, Self::Superstate<'_>>,
         _event: &Self::Event<'_>,
+        _context: &mut Self::Context<'_>,
     ) {
     }
 
     /// Method that is called *before* every transition.
-    fn before_transition(&mut self, _source: &Self::State, _target: &Self::State) {}
+    fn before_transition(
+        &mut self,
+        _source: &Self::State,
+        _target: &Self::State,
+        _context: &mut Self::Context<'_>,
+    ) {
+    }
 
     /// Method that is called *after* every transition.
-    fn after_transition(&mut self, _source: &Self::State, _target: &Self::State) {}
+    fn after_transition(
+        &mut self,
+        _source: &Self::State,
+        _target: &Self::State,
+        _context: &mut Self::Context<'_>,
+    ) {
+    }
 }

--- a/statig/src/blocking/state.rs
+++ b/statig/src/blocking/state.rs
@@ -93,11 +93,21 @@ where
     where
         Self: Sized,
     {
-        M::before_dispatch(shared_storage, StateOrSuperstate::State(self), event);
+        M::before_dispatch(
+            shared_storage,
+            StateOrSuperstate::State(self),
+            event,
+            context,
+        );
 
         let response = self.call_handler(shared_storage, event, context);
 
-        M::after_dispatch(shared_storage, StateOrSuperstate::State(self), event);
+        M::after_dispatch(
+            shared_storage,
+            StateOrSuperstate::State(self),
+            event,
+            context,
+        );
 
         match response {
             Response::Handled => Response::Handled,
@@ -107,6 +117,7 @@ where
                         shared_storage,
                         StateOrSuperstate::Superstate(&superstate),
                         event,
+                        context,
                     );
 
                     let response = superstate.handle(shared_storage, event, context);
@@ -115,6 +126,7 @@ where
                         shared_storage,
                         StateOrSuperstate::Superstate(&superstate),
                         event,
+                        context,
                     );
 
                     response

--- a/statig/src/blocking/superstate.rs
+++ b/statig/src/blocking/superstate.rs
@@ -106,6 +106,7 @@ where
                         shared_storage,
                         StateOrSuperstate::Superstate(&superstate),
                         event,
+                        context
                     );
 
                     let response = superstate.handle(shared_storage, event, context);
@@ -114,6 +115,7 @@ where
                         shared_storage,
                         StateOrSuperstate::Superstate(&superstate),
                         event,
+                        context
                     );
 
                     response

--- a/statig/tests/async_hooks.rs
+++ b/statig/tests/async_hooks.rs
@@ -41,6 +41,7 @@ mod tests {
             &mut self,
             state_or_superstate: StateOrSuperstate<'_, State, Superstate>,
             event: &Event,
+            _context: &mut (),
         ) {
             self.before_dispatch = true;
         }
@@ -49,15 +50,16 @@ mod tests {
             &mut self,
             state_or_superstate: StateOrSuperstate<'_, State, Superstate>,
             event: &Event,
+            _context: &mut (),
         ) {
             self.after_dispatch = true;
         }
 
-        async fn before_transition(&mut self, source: &State, target: &State) {
+        async fn before_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
             self.before_transition = true;
         }
 
-        async fn after_transition(&mut self, source: &State, target: &State) {
+        async fn after_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
             self.after_transition = true;
         }
     }

--- a/statig/tests/hooks.rs
+++ b/statig/tests/hooks.rs
@@ -40,6 +40,7 @@ mod tests {
             &mut self,
             state_or_superstate: StateOrSuperstate<'_, State, Superstate>,
             event: &Event,
+            _context: &mut (),
         ) {
             self.before_dispatch = true;
         }
@@ -48,15 +49,16 @@ mod tests {
             &mut self,
             state_or_superstate: StateOrSuperstate<'_, State, Superstate>,
             event: &Event,
+            _context: &mut (),
         ) {
             self.after_dispatch = true;
         }
 
-        fn before_transition(&mut self, source: &State, target: &State) {
+        fn before_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
             self.before_transition = true;
         }
 
-        fn after_transition(&mut self, source: &State, target: &State) {
+        fn after_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
             self.after_transition = true;
         }
     }


### PR DESCRIPTION
Issue: https://github.com/mdeloof/statig/issues/45

In this implementation, unlike in state handlers, the context becomes a mandatory argument of the hook functions, even if the state machine doesn't use one. (In which case one would have to specify a `_: &mut ()` argument). Not sure if this is fine, but making it optional would for sure be a bigger change requiring some tinkering with the macros. 
   
Another doubt that I have is if, in this case, context should be `&mut` or not. For now I left it mutable to be consistent with the hooks already taking a `&mut self` argument and to leave more freedom to the user.