### PR TITLE
Rename `Response` to `Outcome`

### DIFF
--- a/examples/macro/async_bench/src/main.rs
+++ b/examples/macro/async_bench/src/main.rs
@@ -29,7 +29,7 @@ pub struct CdPlayer;
 #[state_machine(initial = "State::empty()", state(derive(Debug)))]
 impl CdPlayer {
     #[state]
-    async fn empty(event: &Event) -> Response<State> {
+    async fn empty(event: &Event) -> Outcome<State> {
         match event {
             Event::CdDetected => Transition(State::stopped()),
             Event::OpenClose => Transition(State::open()),
@@ -38,7 +38,7 @@ impl CdPlayer {
     }
 
     #[state]
-    async fn open(event: &Event) -> Response<State> {
+    async fn open(event: &Event) -> Outcome<State> {
         match event {
             Event::OpenClose => Transition(State::empty()),
             _ => Super,
@@ -46,7 +46,7 @@ impl CdPlayer {
     }
 
     #[state]
-    async fn stopped(event: &Event) -> Response<State> {
+    async fn stopped(event: &Event) -> Outcome<State> {
         match event {
             Event::Play => Transition(State::playing()),
             Event::OpenClose => Transition(State::open()),
@@ -56,7 +56,7 @@ impl CdPlayer {
     }
 
     #[state]
-    async fn playing(event: &Event) -> Response<State> {
+    async fn playing(event: &Event) -> Outcome<State> {
         match event {
             Event::OpenClose => Transition(State::open()),
             Event::Pause2 => Transition(State::pause()),
@@ -66,7 +66,7 @@ impl CdPlayer {
     }
 
     #[state]
-    async fn pause(event: &Event) -> Response<State> {
+    async fn pause(event: &Event) -> Outcome<State> {
         match event {
             Event::EndPause => Transition(State::playing()),
             Event::Stop => Transition(State::stopped()),

--- a/examples/macro/async_bench_complex/src/main.rs
+++ b/examples/macro/async_bench_complex/src/main.rs
@@ -61,7 +61,7 @@ struct BenchComplex;
 #[state_machine(initial = "State::s1()", state(derive(Debug)))]
 impl BenchComplex {
     #[state]
-    async fn idle(event: &Event) -> Response<State> {
+    async fn idle(event: &Event) -> Outcome<State> {
         match event {
             Event::E1 => Transition(State::s2()),
             _ => Handled,
@@ -69,7 +69,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s1(event: &Event) -> Response<State> {
+    async fn s1(event: &Event) -> Outcome<State> {
         match event {
             Event::E2 => Transition(State::s2()),
             _ => Handled,
@@ -77,7 +77,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s2(event: &Event) -> Response<State> {
+    async fn s2(event: &Event) -> Outcome<State> {
         match event {
             Event::E3 => Transition(State::s3()),
             _ => Handled,
@@ -85,7 +85,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s3(event: &Event) -> Response<State> {
+    async fn s3(event: &Event) -> Outcome<State> {
         match event {
             Event::E4 => Transition(State::s4()),
             _ => Handled,
@@ -93,7 +93,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s4(event: &Event) -> Response<State> {
+    async fn s4(event: &Event) -> Outcome<State> {
         match event {
             Event::E5 => Transition(State::s5()),
             _ => Handled,
@@ -101,7 +101,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s5(event: &Event) -> Response<State> {
+    async fn s5(event: &Event) -> Outcome<State> {
         match event {
             Event::E6 => Transition(State::s6()),
             _ => Handled,
@@ -109,7 +109,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s6(event: &Event) -> Response<State> {
+    async fn s6(event: &Event) -> Outcome<State> {
         match event {
             Event::E7 => Transition(State::s7()),
             _ => Handled,
@@ -117,7 +117,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s7(event: &Event) -> Response<State> {
+    async fn s7(event: &Event) -> Outcome<State> {
         match event {
             Event::E8 => Transition(State::s8()),
             _ => Handled,
@@ -125,7 +125,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s8(event: &Event) -> Response<State> {
+    async fn s8(event: &Event) -> Outcome<State> {
         match event {
             Event::E9 => Transition(State::s9()),
             _ => Handled,
@@ -133,7 +133,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s9(event: &Event) -> Response<State> {
+    async fn s9(event: &Event) -> Outcome<State> {
         match event {
             Event::E10 => Transition(State::s10()),
             _ => Handled,
@@ -141,7 +141,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s10(event: &Event) -> Response<State> {
+    async fn s10(event: &Event) -> Outcome<State> {
         match event {
             Event::E11 => Transition(State::s11()),
             _ => Handled,
@@ -149,7 +149,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s11(event: &Event) -> Response<State> {
+    async fn s11(event: &Event) -> Outcome<State> {
         match event {
             Event::E12 => Transition(State::s12()),
             _ => Handled,
@@ -157,7 +157,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s12(event: &Event) -> Response<State> {
+    async fn s12(event: &Event) -> Outcome<State> {
         match event {
             Event::E13 => Transition(State::s13()),
             _ => Handled,
@@ -165,7 +165,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s13(event: &Event) -> Response<State> {
+    async fn s13(event: &Event) -> Outcome<State> {
         match event {
             Event::E14 => Transition(State::s14()),
             _ => Handled,
@@ -173,7 +173,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s14(event: &Event) -> Response<State> {
+    async fn s14(event: &Event) -> Outcome<State> {
         match event {
             Event::E15 => Transition(State::s15()),
             _ => Handled,
@@ -181,7 +181,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s15(event: &Event) -> Response<State> {
+    async fn s15(event: &Event) -> Outcome<State> {
         match event {
             Event::E16 => Transition(State::s16()),
             _ => Handled,
@@ -189,7 +189,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s16(event: &Event) -> Response<State> {
+    async fn s16(event: &Event) -> Outcome<State> {
         match event {
             Event::E17 => Transition(State::s17()),
             _ => Handled,
@@ -197,7 +197,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s17(event: &Event) -> Response<State> {
+    async fn s17(event: &Event) -> Outcome<State> {
         match event {
             Event::E18 => Transition(State::s18()),
             _ => Handled,
@@ -205,7 +205,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s18(event: &Event) -> Response<State> {
+    async fn s18(event: &Event) -> Outcome<State> {
         match event {
             Event::E19 => Transition(State::s19()),
             _ => Handled,
@@ -213,7 +213,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s19(event: &Event) -> Response<State> {
+    async fn s19(event: &Event) -> Outcome<State> {
         match event {
             Event::E20 => Transition(State::s20()),
             _ => Handled,
@@ -221,7 +221,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s20(event: &Event) -> Response<State> {
+    async fn s20(event: &Event) -> Outcome<State> {
         match event {
             Event::E21 => Transition(State::s21()),
             _ => Handled,
@@ -229,7 +229,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s21(event: &Event) -> Response<State> {
+    async fn s21(event: &Event) -> Outcome<State> {
         match event {
             Event::E22 => Transition(State::s22()),
             _ => Handled,
@@ -237,7 +237,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s22(event: &Event) -> Response<State> {
+    async fn s22(event: &Event) -> Outcome<State> {
         match event {
             Event::E23 => Transition(State::s23()),
             _ => Handled,
@@ -245,7 +245,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s23(event: &Event) -> Response<State> {
+    async fn s23(event: &Event) -> Outcome<State> {
         match event {
             Event::E24 => Transition(State::s24()),
             _ => Handled,
@@ -253,7 +253,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s24(event: &Event) -> Response<State> {
+    async fn s24(event: &Event) -> Outcome<State> {
         match event {
             Event::E25 => Transition(State::s25()),
             _ => Handled,
@@ -261,7 +261,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s25(event: &Event) -> Response<State> {
+    async fn s25(event: &Event) -> Outcome<State> {
         match event {
             Event::E26 => Transition(State::s26()),
             _ => Handled,
@@ -269,7 +269,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s26(event: &Event) -> Response<State> {
+    async fn s26(event: &Event) -> Outcome<State> {
         match event {
             Event::E27 => Transition(State::s27()),
             _ => Handled,
@@ -277,7 +277,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s27(event: &Event) -> Response<State> {
+    async fn s27(event: &Event) -> Outcome<State> {
         match event {
             Event::E28 => Transition(State::s28()),
             _ => Handled,
@@ -285,7 +285,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s28(event: &Event) -> Response<State> {
+    async fn s28(event: &Event) -> Outcome<State> {
         match event {
             Event::E29 => Transition(State::s29()),
             _ => Handled,
@@ -293,7 +293,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s29(event: &Event) -> Response<State> {
+    async fn s29(event: &Event) -> Outcome<State> {
         match event {
             Event::E30 => Transition(State::s30()),
             _ => Handled,
@@ -301,7 +301,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s30(event: &Event) -> Response<State> {
+    async fn s30(event: &Event) -> Outcome<State> {
         match event {
             Event::E31 => Transition(State::s31()),
             _ => Handled,
@@ -309,7 +309,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s31(event: &Event) -> Response<State> {
+    async fn s31(event: &Event) -> Outcome<State> {
         match event {
             Event::E32 => Transition(State::s32()),
             _ => Handled,
@@ -317,7 +317,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s32(event: &Event) -> Response<State> {
+    async fn s32(event: &Event) -> Outcome<State> {
         match event {
             Event::E33 => Transition(State::s33()),
             _ => Handled,
@@ -325,7 +325,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s33(event: &Event) -> Response<State> {
+    async fn s33(event: &Event) -> Outcome<State> {
         match event {
             Event::E34 => Transition(State::s34()),
             _ => Handled,
@@ -333,7 +333,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s34(event: &Event) -> Response<State> {
+    async fn s34(event: &Event) -> Outcome<State> {
         match event {
             Event::E35 => Transition(State::s35()),
             _ => Handled,
@@ -341,7 +341,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s35(event: &Event) -> Response<State> {
+    async fn s35(event: &Event) -> Outcome<State> {
         match event {
             Event::E36 => Transition(State::s36()),
             _ => Handled,
@@ -349,7 +349,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s36(event: &Event) -> Response<State> {
+    async fn s36(event: &Event) -> Outcome<State> {
         match event {
             Event::E37 => Transition(State::s37()),
             _ => Handled,
@@ -357,7 +357,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s37(event: &Event) -> Response<State> {
+    async fn s37(event: &Event) -> Outcome<State> {
         match event {
             Event::E38 => Transition(State::s38()),
             _ => Handled,
@@ -365,7 +365,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s38(event: &Event) -> Response<State> {
+    async fn s38(event: &Event) -> Outcome<State> {
         match event {
             Event::E39 => Transition(State::s39()),
             _ => Handled,
@@ -373,7 +373,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s39(event: &Event) -> Response<State> {
+    async fn s39(event: &Event) -> Outcome<State> {
         match event {
             Event::E40 => Transition(State::s40()),
             _ => Handled,
@@ -381,7 +381,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s40(event: &Event) -> Response<State> {
+    async fn s40(event: &Event) -> Outcome<State> {
         match event {
             Event::E41 => Transition(State::s41()),
             _ => Handled,
@@ -389,7 +389,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s41(event: &Event) -> Response<State> {
+    async fn s41(event: &Event) -> Outcome<State> {
         match event {
             Event::E42 => Transition(State::s42()),
             _ => Handled,
@@ -397,7 +397,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s42(event: &Event) -> Response<State> {
+    async fn s42(event: &Event) -> Outcome<State> {
         match event {
             Event::E43 => Transition(State::s43()),
             _ => Handled,
@@ -405,7 +405,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s43(event: &Event) -> Response<State> {
+    async fn s43(event: &Event) -> Outcome<State> {
         match event {
             Event::E44 => Transition(State::s44()),
             _ => Handled,
@@ -413,7 +413,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s44(event: &Event) -> Response<State> {
+    async fn s44(event: &Event) -> Outcome<State> {
         match event {
             Event::E45 => Transition(State::s45()),
             _ => Handled,
@@ -421,7 +421,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s45(event: &Event) -> Response<State> {
+    async fn s45(event: &Event) -> Outcome<State> {
         match event {
             Event::E46 => Transition(State::s46()),
             _ => Handled,
@@ -429,7 +429,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s46(event: &Event) -> Response<State> {
+    async fn s46(event: &Event) -> Outcome<State> {
         match event {
             Event::E47 => Transition(State::s47()),
             _ => Handled,
@@ -437,7 +437,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s47(event: &Event) -> Response<State> {
+    async fn s47(event: &Event) -> Outcome<State> {
         match event {
             Event::E48 => Transition(State::s48()),
             _ => Handled,
@@ -445,7 +445,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s48(event: &Event) -> Response<State> {
+    async fn s48(event: &Event) -> Outcome<State> {
         match event {
             Event::E49 => Transition(State::s49()),
             _ => Handled,
@@ -453,7 +453,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s49(event: &Event) -> Response<State> {
+    async fn s49(event: &Event) -> Outcome<State> {
         match event {
             Event::E50 => Transition(State::s50()),
             _ => Handled,
@@ -461,7 +461,7 @@ impl BenchComplex {
     }
 
     #[state]
-    async fn s50(event: &Event) -> Response<State> {
+    async fn s50(event: &Event) -> Outcome<State> {
         match event {
             Event::E51 => Transition(State::idle()),
             _ => Handled,

--- a/examples/macro/async_blinky/src/main.rs
+++ b/examples/macro/async_blinky/src/main.rs
@@ -41,9 +41,9 @@ impl Blinky {
     fn cool() {}
     /// The `#[state]` attibute marks this as a state handler.  By default the
     /// `event` argument will map to the event handler by the state machine.
-    /// Every state must return a `Response<State>`.
+    /// Every state must return a `Outcome<State>`.
     #[state(superstate = "blinking", entry_action = "cool")]
-    async fn led_on(event: &Event) -> Response<State> {
+    async fn led_on(event: &Event) -> Outcome<State> {
         match event {
             // When we receive a `TimerElapsed` event we transition to the `led_off` state.
             Event::TimerElapsed => Transition(State::led_off()),
@@ -54,7 +54,7 @@ impl Blinky {
 
     /// Note you can mix sync and async handlers/actions.
     #[state(superstate = "blinking")]
-    fn led_off(event: &Event) -> Response<State> {
+    fn led_off(event: &Event) -> Outcome<State> {
         match event {
             Event::TimerElapsed => Transition(State::led_on()),
             _ => Super,
@@ -63,7 +63,7 @@ impl Blinky {
 
     /// The `#[superstate]` attribute marks this as a superstate handler.
     #[superstate]
-    async fn blinking(event: &Event) -> Response<State> {
+    async fn blinking(event: &Event) -> Outcome<State> {
         match event {
             Event::ButtonPressed => Transition(State::not_blinking()),
             _ => Super,
@@ -71,7 +71,7 @@ impl Blinky {
     }
 
     #[state]
-    async fn not_blinking(event: &Event) -> Response<State> {
+    async fn not_blinking(event: &Event) -> Outcome<State> {
         match event {
             Event::ButtonPressed => Transition(State::led_on()),
             // Altough this state has no superstate, we can still defer the event which

--- a/examples/macro/async_io/src/main.rs
+++ b/examples/macro/async_io/src/main.rs
@@ -24,7 +24,7 @@ impl Receiver {
     }
 
     #[state(entry_action = "enter_on")]
-    async fn on(&mut self, event: &Event) -> Response<State> {
+    async fn on(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Step => {
                 self.connection
@@ -37,7 +37,7 @@ impl Receiver {
     }
 
     #[state]
-    async fn off(&mut self, event: &Event) -> Response<State> {
+    async fn off(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Step => Transition(State::off()),
         }

--- a/examples/macro/barrier/src/main.rs
+++ b/examples/macro/barrier/src/main.rs
@@ -17,7 +17,7 @@ impl Foo {
         #[default] b: &mut bool,
         #[default] c: &mut bool,
         event: &Event,
-    ) -> Response<State> {
+    ) -> Outcome<State> {
         match event {
             Event::A => {
                 *a = true;
@@ -35,7 +35,7 @@ impl Foo {
     }
 
     #[superstate]
-    fn waiting_for_initialization(a: &bool, b: &bool, c: &bool) -> Response<State> {
+    fn waiting_for_initialization(a: &bool, b: &bool, c: &bool) -> Outcome<State> {
         match (a, b, c) {
             (true, true, true) => Transition(State::initialized()),
             _ => Handled,
@@ -43,7 +43,7 @@ impl Foo {
     }
 
     #[state]
-    fn initialized() -> Response<State> {
+    fn initialized() -> Outcome<State> {
         Handled
     }
 }

--- a/examples/macro/basic/src/main.rs
+++ b/examples/macro/basic/src/main.rs
@@ -19,16 +19,16 @@ pub struct Event;
 impl Blinky {
     /// The `#[state]` attibute marks this as a state handler.  By default the
     /// `event` argument will map to the event handler by the state machine.
-    /// Every state must return a `Response<State>`.
+    /// Every state must return a `Outcome<State>`.
     #[state]
-    fn on(&mut self, event: &Event) -> Response<State> {
+    fn on(&mut self, event: &Event) -> Outcome<State> {
         self.led = false;
         // Transition to the `off` state.
         Transition(State::off())
     }
 
     #[state]
-    fn off(&mut self, event: &Event) -> Response<State> {
+    fn off(&mut self, event: &Event) -> Outcome<State> {
         self.led = true;
         // Transition to the `on` state.
         Transition(State::on())

--- a/examples/macro/bench/src/main.rs
+++ b/examples/macro/bench/src/main.rs
@@ -29,7 +29,7 @@ pub struct CdPlayer;
 #[state_machine(initial = "State::empty()", state(derive(Debug)))]
 impl CdPlayer {
     #[state]
-    fn empty(event: &Event) -> Response<State> {
+    fn empty(event: &Event) -> Outcome<State> {
         match event {
             Event::CdDetected => Transition(State::stopped()),
             Event::OpenClose => Transition(State::open()),
@@ -38,7 +38,7 @@ impl CdPlayer {
     }
 
     #[state]
-    fn open(event: &Event) -> Response<State> {
+    fn open(event: &Event) -> Outcome<State> {
         match event {
             Event::OpenClose => Transition(State::empty()),
             _ => Super,
@@ -46,7 +46,7 @@ impl CdPlayer {
     }
 
     #[state]
-    fn stopped(event: &Event) -> Response<State> {
+    fn stopped(event: &Event) -> Outcome<State> {
         match event {
             Event::Play => Transition(State::playing()),
             Event::OpenClose => Transition(State::open()),
@@ -56,7 +56,7 @@ impl CdPlayer {
     }
 
     #[state]
-    fn playing(event: &Event) -> Response<State> {
+    fn playing(event: &Event) -> Outcome<State> {
         match event {
             Event::OpenClose => Transition(State::open()),
             Event::Pause2 => Transition(State::pause()),
@@ -66,7 +66,7 @@ impl CdPlayer {
     }
 
     #[state]
-    fn pause(event: &Event) -> Response<State> {
+    fn pause(event: &Event) -> Outcome<State> {
         match event {
             Event::EndPause => Transition(State::playing()),
             Event::Stop => Transition(State::stopped()),

--- a/examples/macro/bench_complex/src/main.rs
+++ b/examples/macro/bench_complex/src/main.rs
@@ -61,7 +61,7 @@ struct BenchComplex;
 #[state_machine(initial = "State::s1()", state(derive(Debug)))]
 impl BenchComplex {
     #[state]
-    fn idle(event: &Event) -> Response<State> {
+    fn idle(event: &Event) -> Outcome<State> {
         match event {
             Event::E1 => Transition(State::s2()),
             _ => Handled,
@@ -69,7 +69,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s1(event: &Event) -> Response<State> {
+    fn s1(event: &Event) -> Outcome<State> {
         match event {
             Event::E2 => Transition(State::s2()),
             _ => Handled,
@@ -77,7 +77,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s2(event: &Event) -> Response<State> {
+    fn s2(event: &Event) -> Outcome<State> {
         match event {
             Event::E3 => Transition(State::s3()),
             _ => Handled,
@@ -85,7 +85,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s3(event: &Event) -> Response<State> {
+    fn s3(event: &Event) -> Outcome<State> {
         match event {
             Event::E4 => Transition(State::s4()),
             _ => Handled,
@@ -93,7 +93,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s4(event: &Event) -> Response<State> {
+    fn s4(event: &Event) -> Outcome<State> {
         match event {
             Event::E5 => Transition(State::s5()),
             _ => Handled,
@@ -101,7 +101,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s5(event: &Event) -> Response<State> {
+    fn s5(event: &Event) -> Outcome<State> {
         match event {
             Event::E6 => Transition(State::s6()),
             _ => Handled,
@@ -109,7 +109,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s6(event: &Event) -> Response<State> {
+    fn s6(event: &Event) -> Outcome<State> {
         match event {
             Event::E7 => Transition(State::s7()),
             _ => Handled,
@@ -117,7 +117,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s7(event: &Event) -> Response<State> {
+    fn s7(event: &Event) -> Outcome<State> {
         match event {
             Event::E8 => Transition(State::s8()),
             _ => Handled,
@@ -125,7 +125,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s8(event: &Event) -> Response<State> {
+    fn s8(event: &Event) -> Outcome<State> {
         match event {
             Event::E9 => Transition(State::s9()),
             _ => Handled,
@@ -133,7 +133,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s9(event: &Event) -> Response<State> {
+    fn s9(event: &Event) -> Outcome<State> {
         match event {
             Event::E10 => Transition(State::s10()),
             _ => Handled,
@@ -141,7 +141,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s10(event: &Event) -> Response<State> {
+    fn s10(event: &Event) -> Outcome<State> {
         match event {
             Event::E11 => Transition(State::s11()),
             _ => Handled,
@@ -149,7 +149,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s11(event: &Event) -> Response<State> {
+    fn s11(event: &Event) -> Outcome<State> {
         match event {
             Event::E12 => Transition(State::s12()),
             _ => Handled,
@@ -157,7 +157,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s12(event: &Event) -> Response<State> {
+    fn s12(event: &Event) -> Outcome<State> {
         match event {
             Event::E13 => Transition(State::s13()),
             _ => Handled,
@@ -165,7 +165,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s13(event: &Event) -> Response<State> {
+    fn s13(event: &Event) -> Outcome<State> {
         match event {
             Event::E14 => Transition(State::s14()),
             _ => Handled,
@@ -173,7 +173,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s14(event: &Event) -> Response<State> {
+    fn s14(event: &Event) -> Outcome<State> {
         match event {
             Event::E15 => Transition(State::s15()),
             _ => Handled,
@@ -181,7 +181,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s15(event: &Event) -> Response<State> {
+    fn s15(event: &Event) -> Outcome<State> {
         match event {
             Event::E16 => Transition(State::s16()),
             _ => Handled,
@@ -189,7 +189,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s16(event: &Event) -> Response<State> {
+    fn s16(event: &Event) -> Outcome<State> {
         match event {
             Event::E17 => Transition(State::s17()),
             _ => Handled,
@@ -197,7 +197,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s17(event: &Event) -> Response<State> {
+    fn s17(event: &Event) -> Outcome<State> {
         match event {
             Event::E18 => Transition(State::s18()),
             _ => Handled,
@@ -205,7 +205,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s18(event: &Event) -> Response<State> {
+    fn s18(event: &Event) -> Outcome<State> {
         match event {
             Event::E19 => Transition(State::s19()),
             _ => Handled,
@@ -213,7 +213,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s19(event: &Event) -> Response<State> {
+    fn s19(event: &Event) -> Outcome<State> {
         match event {
             Event::E20 => Transition(State::s20()),
             _ => Handled,
@@ -221,7 +221,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s20(event: &Event) -> Response<State> {
+    fn s20(event: &Event) -> Outcome<State> {
         match event {
             Event::E21 => Transition(State::s21()),
             _ => Handled,
@@ -229,7 +229,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s21(event: &Event) -> Response<State> {
+    fn s21(event: &Event) -> Outcome<State> {
         match event {
             Event::E22 => Transition(State::s22()),
             _ => Handled,
@@ -237,7 +237,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s22(event: &Event) -> Response<State> {
+    fn s22(event: &Event) -> Outcome<State> {
         match event {
             Event::E23 => Transition(State::s23()),
             _ => Handled,
@@ -245,7 +245,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s23(event: &Event) -> Response<State> {
+    fn s23(event: &Event) -> Outcome<State> {
         match event {
             Event::E24 => Transition(State::s24()),
             _ => Handled,
@@ -253,7 +253,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s24(event: &Event) -> Response<State> {
+    fn s24(event: &Event) -> Outcome<State> {
         match event {
             Event::E25 => Transition(State::s25()),
             _ => Handled,
@@ -261,7 +261,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s25(event: &Event) -> Response<State> {
+    fn s25(event: &Event) -> Outcome<State> {
         match event {
             Event::E26 => Transition(State::s26()),
             _ => Handled,
@@ -269,7 +269,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s26(event: &Event) -> Response<State> {
+    fn s26(event: &Event) -> Outcome<State> {
         match event {
             Event::E27 => Transition(State::s27()),
             _ => Handled,
@@ -277,7 +277,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s27(event: &Event) -> Response<State> {
+    fn s27(event: &Event) -> Outcome<State> {
         match event {
             Event::E28 => Transition(State::s28()),
             _ => Handled,
@@ -285,7 +285,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s28(event: &Event) -> Response<State> {
+    fn s28(event: &Event) -> Outcome<State> {
         match event {
             Event::E29 => Transition(State::s29()),
             _ => Handled,
@@ -293,7 +293,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s29(event: &Event) -> Response<State> {
+    fn s29(event: &Event) -> Outcome<State> {
         match event {
             Event::E30 => Transition(State::s30()),
             _ => Handled,
@@ -301,7 +301,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s30(event: &Event) -> Response<State> {
+    fn s30(event: &Event) -> Outcome<State> {
         match event {
             Event::E31 => Transition(State::s31()),
             _ => Handled,
@@ -309,7 +309,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s31(event: &Event) -> Response<State> {
+    fn s31(event: &Event) -> Outcome<State> {
         match event {
             Event::E32 => Transition(State::s32()),
             _ => Handled,
@@ -317,7 +317,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s32(event: &Event) -> Response<State> {
+    fn s32(event: &Event) -> Outcome<State> {
         match event {
             Event::E33 => Transition(State::s33()),
             _ => Handled,
@@ -325,7 +325,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s33(event: &Event) -> Response<State> {
+    fn s33(event: &Event) -> Outcome<State> {
         match event {
             Event::E34 => Transition(State::s34()),
             _ => Handled,
@@ -333,7 +333,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s34(event: &Event) -> Response<State> {
+    fn s34(event: &Event) -> Outcome<State> {
         match event {
             Event::E35 => Transition(State::s35()),
             _ => Handled,
@@ -341,7 +341,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s35(event: &Event) -> Response<State> {
+    fn s35(event: &Event) -> Outcome<State> {
         match event {
             Event::E36 => Transition(State::s36()),
             _ => Handled,
@@ -349,7 +349,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s36(event: &Event) -> Response<State> {
+    fn s36(event: &Event) -> Outcome<State> {
         match event {
             Event::E37 => Transition(State::s37()),
             _ => Handled,
@@ -357,7 +357,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s37(event: &Event) -> Response<State> {
+    fn s37(event: &Event) -> Outcome<State> {
         match event {
             Event::E38 => Transition(State::s38()),
             _ => Handled,
@@ -365,7 +365,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s38(event: &Event) -> Response<State> {
+    fn s38(event: &Event) -> Outcome<State> {
         match event {
             Event::E39 => Transition(State::s39()),
             _ => Handled,
@@ -373,7 +373,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s39(event: &Event) -> Response<State> {
+    fn s39(event: &Event) -> Outcome<State> {
         match event {
             Event::E40 => Transition(State::s40()),
             _ => Handled,
@@ -381,7 +381,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s40(event: &Event) -> Response<State> {
+    fn s40(event: &Event) -> Outcome<State> {
         match event {
             Event::E41 => Transition(State::s41()),
             _ => Handled,
@@ -389,7 +389,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s41(event: &Event) -> Response<State> {
+    fn s41(event: &Event) -> Outcome<State> {
         match event {
             Event::E42 => Transition(State::s42()),
             _ => Handled,
@@ -397,7 +397,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s42(event: &Event) -> Response<State> {
+    fn s42(event: &Event) -> Outcome<State> {
         match event {
             Event::E43 => Transition(State::s43()),
             _ => Handled,
@@ -405,7 +405,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s43(event: &Event) -> Response<State> {
+    fn s43(event: &Event) -> Outcome<State> {
         match event {
             Event::E44 => Transition(State::s44()),
             _ => Handled,
@@ -413,7 +413,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s44(event: &Event) -> Response<State> {
+    fn s44(event: &Event) -> Outcome<State> {
         match event {
             Event::E45 => Transition(State::s45()),
             _ => Handled,
@@ -421,7 +421,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s45(event: &Event) -> Response<State> {
+    fn s45(event: &Event) -> Outcome<State> {
         match event {
             Event::E46 => Transition(State::s46()),
             _ => Handled,
@@ -429,7 +429,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s46(event: &Event) -> Response<State> {
+    fn s46(event: &Event) -> Outcome<State> {
         match event {
             Event::E47 => Transition(State::s47()),
             _ => Handled,
@@ -437,7 +437,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s47(event: &Event) -> Response<State> {
+    fn s47(event: &Event) -> Outcome<State> {
         match event {
             Event::E48 => Transition(State::s48()),
             _ => Handled,
@@ -445,7 +445,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s48(event: &Event) -> Response<State> {
+    fn s48(event: &Event) -> Outcome<State> {
         match event {
             Event::E49 => Transition(State::s49()),
             _ => Handled,
@@ -453,7 +453,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s49(event: &Event) -> Response<State> {
+    fn s49(event: &Event) -> Outcome<State> {
         match event {
             Event::E50 => Transition(State::s50()),
             _ => Handled,
@@ -461,7 +461,7 @@ impl BenchComplex {
     }
 
     #[state]
-    fn s50(event: &Event) -> Response<State> {
+    fn s50(event: &Event) -> Outcome<State> {
         match event {
             Event::E51 => Transition(State::idle()),
             _ => Handled,

--- a/examples/macro/blinky/src/main.rs
+++ b/examples/macro/blinky/src/main.rs
@@ -33,9 +33,9 @@ pub enum Event {
 impl Blinky {
     /// The `#[state]` attibute marks this as a state handler.  By default the
     /// `event` argument will map to the event handler by the state machine.
-    /// Every state must return a `Response<State>`.
+    /// Every state must return a `Outcome<State>`.
     #[state(superstate = "blinking")]
-    fn led_on(event: &Event) -> Response<State> {
+    fn led_on(event: &Event) -> Outcome<State> {
         match event {
             // When we receive a `TimerElapsed` event we transition to the `led_off` state.
             Event::TimerElapsed => Transition(State::led_off()),
@@ -45,7 +45,7 @@ impl Blinky {
     }
 
     #[state(superstate = "blinking")]
-    fn led_off(event: &Event) -> Response<State> {
+    fn led_off(event: &Event) -> Outcome<State> {
         match event {
             Event::TimerElapsed => Transition(State::led_on()),
             _ => Super,
@@ -54,7 +54,7 @@ impl Blinky {
 
     /// The `#[superstate]` attribute marks this as a superstate handler.
     #[superstate]
-    fn blinking(event: &Event) -> Response<State> {
+    fn blinking(event: &Event) -> Outcome<State> {
         match event {
             Event::ButtonPressed => Transition(State::not_blinking()),
             _ => Super,
@@ -62,7 +62,7 @@ impl Blinky {
     }
 
     #[state]
-    fn not_blinking(event: &Event) -> Response<State> {
+    fn not_blinking(event: &Event) -> Outcome<State> {
         match event {
             Event::ButtonPressed => Transition(State::led_on()),
             // Altough this state has no superstate, we can still defer the event which

--- a/examples/macro/calculator/src/state.rs
+++ b/examples/macro/calculator/src/state.rs
@@ -45,7 +45,7 @@ impl Calculator {
     ///
     /// - [`Event::Operator`] => [`negated1`](Self::negated1)
     #[state(superstate = "ready", entry_action = "enter_begin")]
-    fn begin(&mut self, event: &Event) -> Response<State> {
+    fn begin(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Operator {
                 operator: Operator::Sub,
@@ -69,7 +69,7 @@ impl Calculator {
         entry_action = "enter_result",
         local_storage("result: f32")
     )]
-    fn result(event: &Event) -> Response<State> {
+    fn result(event: &Event) -> Outcome<State> {
         #[allow(clippy::match_single_binding)]
         match event {
             _ => Super,
@@ -84,7 +84,7 @@ impl Calculator {
     /// - [`Event::Ac`] => [`begin`](Self::begin)
     /// - [`Event::Ce`] => [`begin`](Self::begin)
     #[superstate(superstate = "on")]
-    fn ready(&mut self, event: &Event) -> Response<State> {
+    fn ready(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: 0 } => {
                 self.display.clear();
@@ -120,7 +120,7 @@ impl Calculator {
     /// - [`Event::Digit`] => [`int1`](Self::int1) | `(handled)`
     /// - [`Event::Point`] => [`frac1`](Self::frac1)
     #[state(superstate = "operand1")]
-    fn zero1(&mut self, event: &Event) -> Response<State> {
+    fn zero1(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: 0 } => Handled,
 
@@ -143,7 +143,7 @@ impl Calculator {
     /// - [`Event::Point`] => [`frac1`](Self::frac1)
     /// - [`Event::Digit`] => `(handled)`
     #[state(superstate = "operand1")]
-    fn int1(&mut self, event: &Event) -> Response<State> {
+    fn int1(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Point => {
                 self.display.push('.');
@@ -164,7 +164,7 @@ impl Calculator {
     /// - [`Event::Point`] => `(handled)`
     /// - [`Event::Digit`] => `(handled)`
     #[state(superstate = "operand1")]
-    fn frac1(&mut self, event: &Event) -> Response<State> {
+    fn frac1(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Point => Handled,
 
@@ -185,7 +185,7 @@ impl Calculator {
     /// - [`Event::Operator`] => `(handled)`
     /// - [`Event::Ac`] => [`begin`](Self::begin)
     #[state(superstate = "operand1")]
-    fn negated1(&mut self, event: &Event) -> Response<State> {
+    fn negated1(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: digit @ 0 } => {
                 self.display.clear();
@@ -224,7 +224,7 @@ impl Calculator {
     /// - [`Event::Operator`] => [`op_entered`](Self::op_entered)
     /// - [`Event::Equal`] => [`result`](Self::result)
     #[superstate(superstate = "on")]
-    fn operand1(&mut self, event: &Event) -> Response<State> {
+    fn operand1(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Ac => {
                 self.display.clear();
@@ -260,7 +260,7 @@ impl Calculator {
         operand1: &f32,
         operator: &Operator,
         event: &Event,
-    ) -> Response<State> {
+    ) -> Outcome<State> {
         match event {
             Event::Digit { digit: 0 } => {
                 self.display = "0".to_string();
@@ -296,7 +296,7 @@ impl Calculator {
     /// - [`Event::Digit`] => [`int2`](Self::int2) | `(handled)`
     /// - [`Event::Point`] => [`frac2`](Self::frac2)
     #[state(superstate = "operand2")]
-    fn zero2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Response<State> {
+    fn zero2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: 0 } => Handled,
 
@@ -319,7 +319,7 @@ impl Calculator {
     /// - [`Event::Point`] => [`frac2`](Self::frac2)
     /// - [`Event::Digit`] => `(handled)`
     #[state(superstate = "operand2")]
-    fn int2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Response<State> {
+    fn int2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
             Event::Point => {
                 self.display.push('.');
@@ -343,7 +343,7 @@ impl Calculator {
         superstate = "operand2",
         local_storage("operand1: f32", "operator: Operator")
     )]
-    fn frac2(&mut self, event: &Event) -> Response<State> {
+    fn frac2(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Point => Handled,
 
@@ -362,7 +362,7 @@ impl Calculator {
     /// - [`Event::Equal`] => [`result`](Self::result)
     /// - [`Event::Operator`] => [`op_entered`](Self::op_entered)
     #[superstate(superstate = "on")]
-    fn operand2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Response<State> {
+    fn operand2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
             Event::Ac => {
                 self.display.clear();
@@ -400,7 +400,7 @@ impl Calculator {
     /// - [`Event::Operator`] => `(handled)`
     /// - [`Event::Ac`] => [`op_entered`](Self::op_entered)
     #[state(superstate = "on")]
-    fn negated2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Response<State> {
+    fn negated2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: digit @ 0 } => {
                 self.display.clear();
@@ -437,7 +437,7 @@ impl Calculator {
     ///
     /// - [`Event::Ac`] => [`begin`](Self::begin)
     #[superstate]
-    fn on(&mut self, event: &Event) -> Response<State> {
+    fn on(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Ac => {
                 self.display.clear();

--- a/examples/macro/custom_state/src/main.rs
+++ b/examples/macro/custom_state/src/main.rs
@@ -44,9 +44,9 @@ impl CustomState {
 impl Blinky {
     /// The `#[state]` attibute marks this as a state handler.  By default the
     /// `event` argument will map to the event handler by the state machine.
-    /// Every state must return a `Response<CustomState>`.
+    /// Every state must return a `Outcome<CustomState>`.
     #[state(superstate = "blinking")]
-    fn led_on(event: &Event) -> Response<CustomState> {
+    fn led_on(event: &Event) -> Outcome<CustomState> {
         match event {
             // When we receive a `TimerElapsed` event we transition to the `led_off` state.
             Event::TimerElapsed => Transition(CustomState::LedOff),
@@ -56,7 +56,7 @@ impl Blinky {
     }
 
     #[state(superstate = "blinking")]
-    fn led_off(event: &Event) -> Response<CustomState> {
+    fn led_off(event: &Event) -> Outcome<CustomState> {
         match event {
             Event::TimerElapsed => Transition(CustomState::LedOn),
             _ => Super,
@@ -65,7 +65,7 @@ impl Blinky {
 
     /// The `#[superstate]` attribute marks this as a superstate handler.
     #[superstate]
-    fn blinking(event: &Event) -> Response<CustomState> {
+    fn blinking(event: &Event) -> Outcome<CustomState> {
         match event {
             Event::ButtonPressed => Transition(CustomState::NotBlinking),
             _ => Super,
@@ -73,7 +73,7 @@ impl Blinky {
     }
 
     #[state]
-    fn not_blinking(event: &Event) -> Response<CustomState> {
+    fn not_blinking(event: &Event) -> Outcome<CustomState> {
         match event {
             Event::ButtonPressed => Transition(CustomState::LedOn),
             // Altough this state has no superstate, we can still defer the event which

--- a/examples/macro/generics/src/main.rs
+++ b/examples/macro/generics/src/main.rs
@@ -29,7 +29,7 @@ where
     A: 'static + Deref,
 {
     #[state]
-    fn foo(event: &Event<T>) -> Response<State<T, SIZE>> {
+    fn foo(event: &Event<T>) -> Outcome<State<T, SIZE>> {
         match event {
             Event::Bar(value) => Transition(State::bar(*value, [T::default(); SIZE])),
             _ => Super,
@@ -42,7 +42,7 @@ where
     }
 
     #[state(superstate = "foo_and_bar", entry_action = "enter_bar")]
-    fn bar(value: &mut T, buffer: &[T; SIZE], event: &Event<T>) -> Response<State<T, SIZE>> {
+    fn bar(value: &mut T, buffer: &[T; SIZE], event: &Event<T>) -> Outcome<State<T, SIZE>> {
         match event {
             Event::Foo => Transition(State::foo()),
             _ => Super,
@@ -50,7 +50,7 @@ where
     }
 
     #[superstate]
-    fn foo_and_bar(value: &mut T) -> Response<State<T, SIZE>> {
+    fn foo_and_bar(value: &mut T) -> Outcome<State<T, SIZE>> {
         Super
     }
 }

--- a/examples/macro/history/src/main.rs
+++ b/examples/macro/history/src/main.rs
@@ -25,7 +25,7 @@ impl Dishwasher {
     }
 
     #[superstate]
-    fn door_closed(event: &Event) -> Response<State> {
+    fn door_closed(event: &Event) -> Outcome<State> {
         match event {
             // When the door is opened the program needs to be paused until
             // the door is closed again.
@@ -35,7 +35,7 @@ impl Dishwasher {
     }
 
     #[state(superstate = "door_closed")]
-    fn idle(event: &Event) -> Response<State> {
+    fn idle(event: &Event) -> Outcome<State> {
         match event {
             Event::StartProgram => Transition(State::soap()),
             _ => Super,
@@ -43,7 +43,7 @@ impl Dishwasher {
     }
 
     #[state(superstate = "door_closed")]
-    fn soap(event: &Event) -> Response<State> {
+    fn soap(event: &Event) -> Outcome<State> {
         match event {
             Event::TimerElapsed => Transition(State::rinse()),
             _ => Super,
@@ -51,7 +51,7 @@ impl Dishwasher {
     }
 
     #[state(superstate = "door_closed")]
-    fn rinse(event: &Event) -> Response<State> {
+    fn rinse(event: &Event) -> Outcome<State> {
         match event {
             Event::TimerElapsed => Transition(State::dry()),
             _ => Super,
@@ -59,7 +59,7 @@ impl Dishwasher {
     }
 
     #[state(superstate = "door_closed")]
-    fn dry(event: &Event) -> Response<State> {
+    fn dry(event: &Event) -> Outcome<State> {
         match event {
             Event::TimerElapsed => Transition(State::idle()),
             _ => Super,
@@ -67,7 +67,7 @@ impl Dishwasher {
     }
 
     #[state]
-    fn door_opened(&self, event: &Event) -> Response<State> {
+    fn door_opened(&self, event: &Event) -> Outcome<State> {
         match event {
             // When the door is closed again, the program is resumed from
             // the previous state.

--- a/examples/no_macro/basic/src/main.rs
+++ b/examples/no_macro/basic/src/main.rs
@@ -41,7 +41,7 @@ impl IntoStateMachine for Blinky {
 }
 
 impl blocking::State<Blinky> for State {
-    fn call_handler(&mut self, blinky: &mut Blinky, event: &Event, _: &mut ()) -> Response<Self> {
+    fn call_handler(&mut self, blinky: &mut Blinky, event: &Event, _: &mut ()) -> Outcome<Self> {
         match self {
             State::On => blinky.on(event),
             State::Off => blinky.off(event),
@@ -50,13 +50,13 @@ impl blocking::State<Blinky> for State {
 }
 
 impl Blinky {
-    fn on(&mut self, event: &Event) -> Response<State> {
+    fn on(&mut self, event: &Event) -> Outcome<State> {
         self.led = false;
         // Transition to the `off` state.
         Transition(State::Off)
     }
 
-    fn off(&mut self, event: &Event) -> Response<State> {
+    fn off(&mut self, event: &Event) -> Outcome<State> {
         self.led = true;
         // Transition to the `on` state.
         Transition(State::On)

--- a/examples/no_macro/bench/src/main.rs
+++ b/examples/no_macro/bench/src/main.rs
@@ -60,7 +60,7 @@ impl blocking::State<CdPlayer> for State {
         cd_player: &mut CdPlayer,
         event: &Event,
         _: &mut (),
-    ) -> Response<Self> {
+    ) -> Outcome<Self> {
         match self {
             State::Empty => CdPlayer::empty(event),
             State::Open => CdPlayer::open(event),
@@ -72,7 +72,7 @@ impl blocking::State<CdPlayer> for State {
 }
 
 impl CdPlayer {
-    fn empty(event: &Event) -> Response<State> {
+    fn empty(event: &Event) -> Outcome<State> {
         match event {
             Event::CdDetected => (Transition(State::Stopped)),
             Event::OpenClose => (Transition(State::Open)),
@@ -80,14 +80,14 @@ impl CdPlayer {
         }
     }
 
-    fn open(event: &Event) -> Response<State> {
+    fn open(event: &Event) -> Outcome<State> {
         match event {
             Event::OpenClose => (Transition(State::Empty)),
             _ => (Super),
         }
     }
 
-    fn stopped(event: &Event) -> Response<State> {
+    fn stopped(event: &Event) -> Outcome<State> {
         match event {
             Event::Play => (Transition(State::Playing)),
             Event::OpenClose => (Transition(State::Open)),
@@ -96,7 +96,7 @@ impl CdPlayer {
         }
     }
 
-    fn playing(event: &Event) -> Response<State> {
+    fn playing(event: &Event) -> Outcome<State> {
         match event {
             Event::OpenClose => (Transition(State::Open)),
             Event::Pause2 => (Transition(State::Pause)),
@@ -105,7 +105,7 @@ impl CdPlayer {
         }
     }
 
-    fn pause(event: &Event) -> Response<State> {
+    fn pause(event: &Event) -> Outcome<State> {
         match event {
             Event::EndPause => (Transition(State::Playing)),
             Event::Stop => (Transition(State::Stopped)),

--- a/examples/no_macro/blinky/src/main.rs
+++ b/examples/no_macro/blinky/src/main.rs
@@ -48,7 +48,7 @@ impl IntoStateMachine for Blinky {
 
 // Implement the `statig::State` trait for the state enum.
 impl blocking::State<Blinky> for State {
-    fn call_handler(&mut self, blinky: &mut Blinky, event: &Event, _: &mut ()) -> Response<Self> {
+    fn call_handler(&mut self, blinky: &mut Blinky, event: &Event, _: &mut ()) -> Outcome<Self> {
         match self {
             State::LedOn => Blinky::led_on(event),
             State::LedOff => Blinky::led_off(event),
@@ -67,7 +67,7 @@ impl blocking::State<Blinky> for State {
 
 // Implement the `statig::Superstate` trait for the superstate enum.
 impl blocking::Superstate<Blinky> for Superstate {
-    fn call_handler(&mut self, blinky: &mut Blinky, event: &Event, _: &mut ()) -> Response<State> {
+    fn call_handler(&mut self, blinky: &mut Blinky, event: &Event, _: &mut ()) -> Outcome<State> {
         match self {
             Superstate::Blinking => Blinky::blinking(event),
         }
@@ -75,28 +75,28 @@ impl blocking::Superstate<Blinky> for Superstate {
 }
 
 impl Blinky {
-    fn led_on(event: &Event) -> Response<State> {
+    fn led_on(event: &Event) -> Outcome<State> {
         match event {
             Event::TimerElapsed => Transition(State::LedOff),
             _ => Super,
         }
     }
 
-    fn led_off(event: &Event) -> Response<State> {
+    fn led_off(event: &Event) -> Outcome<State> {
         match event {
             Event::TimerElapsed => Transition(State::LedOn),
             _ => Super,
         }
     }
 
-    fn blinking(event: &Event) -> Response<State> {
+    fn blinking(event: &Event) -> Outcome<State> {
         match event {
             Event::ButtonPressed => Transition(State::NotBlinking),
             _ => Super,
         }
     }
 
-    fn not_blinking(event: &Event) -> Response<State> {
+    fn not_blinking(event: &Event) -> Outcome<State> {
         match event {
             Event::ButtonPressed => Transition(State::LedOn),
             _ => Super,

--- a/examples/no_macro/calculator/src/state.rs
+++ b/examples/no_macro/calculator/src/state.rs
@@ -77,7 +77,7 @@ impl blocking::State<Calculator> for State {
         calculator: &mut Calculator,
         event: &Event,
         _: &mut (),
-    ) -> Response<Self> {
+    ) -> Outcome<Self> {
         match self {
             State::Begin => Calculator::begin(calculator, event),
             State::Response { result } => Calculator::result(result, event),
@@ -138,7 +138,7 @@ impl<'sub> blocking::Superstate<Calculator> for Superstate<'sub> {
         calculator: &mut Calculator,
         event: &Event,
         _: &mut (),
-    ) -> Response<State> {
+    ) -> Outcome<State> {
         match self {
             Superstate::Ready => Calculator::ready(calculator, event),
             Superstate::Operand1 => Calculator::operand1(calculator, event),
@@ -168,7 +168,7 @@ impl Calculator {
     /// The initial state of the calculator.
     ///
     /// - [`Event::Operator`] => [`negated1`](Self::negated1)
-    fn begin(&mut self, event: &Event) -> Response<State> {
+    fn begin(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Operator {
                 operator: Operator::Sub,
@@ -187,7 +187,7 @@ impl Calculator {
 
     /// Show the result of the calculation.
     #[allow(unused)]
-    fn result(result: &f32, event: &Event) -> Response<State> {
+    fn result(result: &f32, event: &Event) -> Outcome<State> {
         #[allow(clippy::match_single_binding)]
         match event {
             _ => Super,
@@ -201,7 +201,7 @@ impl Calculator {
     /// - [`Event::Operator`] => [`op_entered`](Self::op_entered)
     /// - [`Event::Ac`] => [`begin`](Self::begin)
     /// - [`Event::Ce`] => [`begin`](Self::begin)
-    fn ready(&mut self, event: &Event) -> Response<State> {
+    fn ready(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: 0 } => {
                 self.display.clear();
@@ -239,7 +239,7 @@ impl Calculator {
     ///
     /// - [`Event::Digit`] => [`int1`](Self::int1) | `(handled)`
     /// - [`Event::Point`] => [`frac1`](Self::frac1)
-    fn zero1(&mut self, event: &Event) -> Response<State> {
+    fn zero1(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: 0 } => Handled,
 
@@ -261,7 +261,7 @@ impl Calculator {
     ///
     /// - [`Event::Point`] => [`frac1`](Self::frac1)
     /// - [`Event::Digit`] => `(handled)`
-    fn int1(&mut self, event: &Event) -> Response<State> {
+    fn int1(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Point => {
                 self.display.push('.');
@@ -281,7 +281,7 @@ impl Calculator {
     ///
     /// - [`Event::Point`] => `(handled)`
     /// - [`Event::Digit`] => `(handled)`
-    fn frac1(&mut self, event: &Event) -> Response<State> {
+    fn frac1(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Point => Handled,
 
@@ -301,7 +301,7 @@ impl Calculator {
     /// - [`Event::Point`] => [`frac1`](Self::frac1)
     /// - [`Event::Operator`] => `(handled)`
     /// - [`Event::Ac`] => [`begin`](Self::begin)
-    fn negated1(&mut self, event: &Event) -> Response<State> {
+    fn negated1(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: digit @ 0 } => {
                 self.display.clear();
@@ -339,7 +339,7 @@ impl Calculator {
     /// - [`Event::Ac`] => [`begin`](Self::begin)
     /// - [`Event::Operator`] => [`op_entered`](Self::op_entered)
     /// - [`Event::Equal`] => [`result`](Self::result)
-    fn operand1(&mut self, event: &Event) -> Response<State> {
+    fn operand1(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Ac => {
                 self.display.clear();
@@ -372,12 +372,7 @@ impl Calculator {
     /// - [`Event::Digit`] => [`zero2`](Self::zero2) | [`int2`](Self::int2)
     /// - [`Event::Point`] => [`frac2`](Self::frac2)
     /// - [`Event::Operator`] => [`negated2`](Self::negated2) | `(handled)`
-    fn op_entered(
-        &mut self,
-        operand1: &f32,
-        operator: &Operator,
-        event: &Event,
-    ) -> Response<State> {
+    fn op_entered(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: 0 } => {
                 self.display = "0".to_string();
@@ -424,7 +419,7 @@ impl Calculator {
     ///
     /// - [`Event::Digit`] => [`int2`](Self::int2) | `(handled)`
     /// - [`Event::Point`] => [`frac2`](Self::frac2)
-    fn zero2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Response<State> {
+    fn zero2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: 0 } => Handled,
 
@@ -452,7 +447,7 @@ impl Calculator {
     ///
     /// - [`Event::Point`] => [`frac2`](Self::frac2)
     /// - [`Event::Digit`] => `(handled)`
-    fn int2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Response<State> {
+    fn int2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
             Event::Point => {
                 self.display.push('.');
@@ -476,7 +471,7 @@ impl Calculator {
     /// - [`Event::Point`] => `(handled)`
     /// - [`Event::Digit`] => `(handled)`
     #[allow(unused)]
-    fn frac2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Response<State> {
+    fn frac2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
             Event::Point => Handled,
 
@@ -494,7 +489,7 @@ impl Calculator {
     /// - [`Event::Ac`] => [`op_entered`](Self::op_entered)
     /// - [`Event::Equal`] => [`result`](Self::result)
     /// - [`Event::Operator`] => [`op_entered`](Self::op_entered)
-    fn operand2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Response<State> {
+    fn operand2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
             Event::Ac => {
                 self.display.clear();
@@ -537,7 +532,7 @@ impl Calculator {
     /// - [`Event::Point`] => [`frac2`](Self::frac2)
     /// - [`Event::Operator`] => `(handled)`
     /// - [`Event::Ac`] => [`op_entered`](Self::op_entered)
-    fn negated2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Response<State> {
+    fn negated2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
             Event::Digit { digit: digit @ 0 } => {
                 self.display.clear();
@@ -585,7 +580,7 @@ impl Calculator {
     /// The calculator is on and ready to receive events.
     ///
     /// - [`Event::Ac`] => [`begin`](Self::begin)
-    fn on(&mut self, event: &Event) -> Response<State> {
+    fn on(&mut self, event: &Event) -> Outcome<State> {
         match event {
             Event::Ac => {
                 self.display.clear();

--- a/examples/no_macro/history/src/main.rs
+++ b/examples/no_macro/history/src/main.rs
@@ -53,7 +53,7 @@ impl blocking::State<Dishwasher> for State {
         shared: &mut Dishwasher,
         event: &Event,
         _: &mut (),
-    ) -> Response<Self> {
+    ) -> Outcome<Self> {
         match self {
             State::DoorOpened => Dishwasher::door_opened(shared, event),
             State::Dry => Dishwasher::dry(event),
@@ -80,7 +80,7 @@ impl blocking::Superstate<Dishwasher> for Superstate {
         shared: &mut Dishwasher,
         event: &Event,
         _: &mut (),
-    ) -> Response<State> {
+    ) -> Outcome<State> {
         match self {
             Superstate::DoorClosed => Dishwasher::door_closed(event),
         }
@@ -88,35 +88,35 @@ impl blocking::Superstate<Dishwasher> for Superstate {
 }
 
 impl Dishwasher {
-    fn idle(event: &Event) -> Response<State> {
+    fn idle(event: &Event) -> Outcome<State> {
         match event {
             Event::StartProgram => Transition(State::Soap),
             _ => Super,
         }
     }
 
-    fn soap(event: &Event) -> Response<State> {
+    fn soap(event: &Event) -> Outcome<State> {
         match event {
             Event::TimerElapsed => Transition(State::Rinse),
             _ => Super,
         }
     }
 
-    fn rinse(event: &Event) -> Response<State> {
+    fn rinse(event: &Event) -> Outcome<State> {
         match event {
             Event::TimerElapsed => Transition(State::Dry),
             _ => Super,
         }
     }
 
-    fn dry(event: &Event) -> Response<State> {
+    fn dry(event: &Event) -> Outcome<State> {
         match event {
             Event::TimerElapsed => Transition(State::Idle),
             _ => Super,
         }
     }
 
-    fn door_closed(event: &Event) -> Response<State> {
+    fn door_closed(event: &Event) -> Outcome<State> {
         match event {
             // When the door is opened the program needs to be paused until
             // the door is closed again.
@@ -125,7 +125,7 @@ impl Dishwasher {
         }
     }
 
-    fn door_opened(&mut self, event: &Event) -> Response<State> {
+    fn door_opened(&mut self, event: &Event) -> Outcome<State> {
         match event {
             // When the door is closed again, the program is resumed from
             // the previous state.

--- a/macro/src/analyze.rs
+++ b/macro/src/analyze.rs
@@ -711,13 +711,13 @@ fn valid_state_analyze() {
                 entry_action = "enter_on",
                 exit_action = "enter_off"
             )]
-            fn on(&mut self, event: &Event) -> Response<State> {
-                Response::Handled
+            fn on(&mut self, event: &Event) -> Outcome<State> {
+                Outcome::Handled
             }
 
             #[superstate]
-            fn playing(&mut self, event: &Event) -> Response<State> {
-                Response::Handled
+            fn playing(&mut self, event: &Event) -> Outcome<State> {
+                Outcome::Handled
             }
 
             #[action]

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -247,7 +247,7 @@ fn codegen_state_impl_state(ir: &Ir) -> ItemImpl {
         superstate_arms.push(parse_quote!(#pat => #superstate_pat));
     }
 
-    call_handler_arms.push(parse_quote!(_ => statig::Response::Super));
+    call_handler_arms.push(parse_quote!(_ => statig::Outcome::Super));
     call_entry_action_arms.push(parse_quote!(_ => {}));
     call_exit_action_arms.push(parse_quote!(_ => {}));
     superstate_arms.push(parse_quote!(_ => None));
@@ -264,7 +264,7 @@ fn codegen_state_impl_state(ir: &Ir) -> ItemImpl {
                         shared_storage: &mut #shared_storage_type,
                         #event_ident: &<#shared_storage_type as statig::blocking::IntoStateMachine>::Event<'_>,
                         #context_ident: &mut <#shared_storage_type as statig::blocking::IntoStateMachine>::Context<'_>
-                    ) -> statig::Response<Self> where Self: Sized {
+                    ) -> statig::Outcome<Self> where Self: Sized {
                         match self {
                             #(#call_handler_arms),*
                         }
@@ -308,7 +308,7 @@ fn codegen_state_impl_state(ir: &Ir) -> ItemImpl {
                     shared_storage: &mut #shared_storage_type,
                     #event_ident: &<#shared_storage_type as statig::awaitable::IntoStateMachine>::Event<'_>,
                     #context_ident: &mut <#shared_storage_type as statig::awaitable::IntoStateMachine>::Context<'_>
-                ) -> impl core::future::Future<Output = statig::Response<Self>> {
+                ) -> impl core::future::Future<Output = statig::Outcome<Self>> {
                     async move {
                         match self {
                             #(#call_handler_arms),*
@@ -421,7 +421,7 @@ fn codegen_superstate_impl_superstate(ir: &Ir) -> ItemImpl {
         superstate_arms.push(parse_quote!(#pat => #superstate_pat));
     }
 
-    call_handler_arms.push(parse_quote!(_ => statig::Response::Super));
+    call_handler_arms.push(parse_quote!(_ => statig::Outcome::Super));
     call_entry_action_arms.push(parse_quote!(_ => {}));
     call_exit_action_arms.push(parse_quote!(_ => {}));
     superstate_arms.push(parse_quote!(_ => None));
@@ -438,7 +438,7 @@ fn codegen_superstate_impl_superstate(ir: &Ir) -> ItemImpl {
                         shared_storage: &mut #shared_storage_type,
                         #event_ident: &<#shared_storage_type as statig::blocking::IntoStateMachine>::Event<'_>,
                         #context_ident: &mut <#shared_storage_type as statig::blocking::IntoStateMachine>::Context<'_>
-                    ) -> statig::Response<<#shared_storage_type as statig::blocking::IntoStateMachine>::State> where Self: Sized {
+                    ) -> statig::Outcome<<#shared_storage_type as statig::blocking::IntoStateMachine>::State> where Self: Sized {
                         match self {
                             #(#call_handler_arms),*
                         }
@@ -483,7 +483,7 @@ fn codegen_superstate_impl_superstate(ir: &Ir) -> ItemImpl {
                         shared_storage: &mut #shared_storage_type,
                         #event_ident: &<#shared_storage_type as statig::awaitable::IntoStateMachine>::Event<'_>,
                         #context_ident: &mut <#shared_storage_type as statig::awaitable::IntoStateMachine>::Context<'_>
-                    ) -> impl core::future::Future<Output = statig::Response<<#shared_storage_type as statig::awaitable::IntoStateMachine>::State>> {
+                    ) -> impl core::future::Future<Output = statig::Outcome<<#shared_storage_type as statig::awaitable::IntoStateMachine>::State>> {
                         async move {
                             match self {
                                 #(#call_handler_arms),*

--- a/macro/src/parse.rs
+++ b/macro/src/parse.rs
@@ -30,12 +30,12 @@ fn valid_input() {
     let token_stream = quote!(
         #[state_machine]
         impl Blinky {
-            fn on(&mut self, event: &Event) -> Reponse<State> {
-                Response::Handled
+            fn on(&mut self, event: &Event) -> Outcome<State> {
+                Outcome::Handled
             }
 
-            fn off(&mut self, event: &Event) -> Response<State> {
-                Response::Handled
+            fn off(&mut self, event: &Event) -> Outcome<State> {
+                Outcome::Handled
             }
         }
     );

--- a/statig/src/awaitable/inner.rs
+++ b/statig/src/awaitable/inner.rs
@@ -1,5 +1,5 @@
 use crate::awaitable::{IntoStateMachine, State, StateExt, Superstate};
-use crate::Response;
+use crate::Outcome;
 
 /// Private internal representation of a state machine that is used for the public types.
 pub(crate) struct Inner<M>
@@ -33,9 +33,9 @@ where
             .handle(&mut self.shared_storage, event, context)
             .await;
         match response {
-            Response::Super => {}
-            Response::Handled => {}
-            Response::Transition(state) => self.transition(state, context).await,
+            Outcome::Super => {}
+            Outcome::Handled => {}
+            Outcome::Transition(state) => self.transition(state, context).await,
         }
     }
 

--- a/statig/src/awaitable/mod.rs
+++ b/statig/src/awaitable/mod.rs
@@ -6,7 +6,7 @@ mod state;
 mod state_machine;
 mod superstate;
 
-pub use crate::Response::{self, *};
+pub use crate::Outcome::{self, *};
 pub use crate::*;
 
 pub(crate) use inner::*;

--- a/statig/src/awaitable/state_machine.rs
+++ b/statig/src/awaitable/state_machine.rs
@@ -134,7 +134,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let state_machine = Blinky::default().state_machine();
@@ -163,7 +163,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let mut state_machine = Blinky::default().state_machine();
@@ -195,7 +195,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let mut state_machine = Blinky::default().state_machine();
@@ -380,7 +380,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// # executor::block_on(async {
@@ -413,7 +413,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// # executor::block_on(async {
@@ -448,7 +448,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// # executor::block_on(async {
@@ -585,7 +585,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// # executor::block_on(async {
@@ -621,7 +621,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// # executor::block_on(async {
@@ -658,7 +658,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -683,7 +683,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -713,7 +713,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Response<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();

--- a/statig/src/awaitable/superstate.rs
+++ b/statig/src/awaitable/superstate.rs
@@ -2,7 +2,7 @@ use core::cmp::Ordering;
 use core::future::Future;
 
 use crate::awaitable::IntoStateMachine;
-use crate::Response;
+use crate::Outcome;
 
 /// An enum that represents the superstates of the state machine.
 pub trait Superstate<M>
@@ -15,7 +15,7 @@ where
         shared_storage: &mut M,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) -> impl Future<Output = Response<M::State>>;
+    ) -> impl Future<Output = Outcome<M::State>>;
 
     #[allow(unused)]
     /// Call the entry action for the current superstate.
@@ -109,8 +109,8 @@ where
         _: &mut M,
         _: &M::Event<'_>,
         _: &mut M::Context<'_>,
-    ) -> impl Future<Output = Response<M::State>> {
-        core::future::ready(Response::Handled)
+    ) -> impl Future<Output = Outcome<M::State>> {
+        core::future::ready(Outcome::Handled)
     }
 
     fn call_entry_action(&mut self, _: &mut M, _: &mut M::Context<'_>) -> impl Future<Output = ()> {

--- a/statig/src/blocking/inner.rs
+++ b/statig/src/blocking/inner.rs
@@ -1,5 +1,5 @@
 use crate::blocking::{IntoStateMachine, State, StateExt, Superstate};
-use crate::Response;
+use crate::Outcome;
 
 /// Private internal representation of a state machine that is used for the public types.
 pub(crate) struct Inner<M>
@@ -31,9 +31,9 @@ where
     ) {
         let response = self.state.handle(&mut self.shared_storage, event, context);
         match response {
-            Response::Super => {}
-            Response::Handled => {}
-            Response::Transition(state) => self.transition(state, context),
+            Outcome::Super => {}
+            Outcome::Handled => {}
+            Outcome::Transition(state) => self.transition(state, context),
         }
     }
 

--- a/statig/src/blocking/mod.rs
+++ b/statig/src/blocking/mod.rs
@@ -6,7 +6,7 @@ mod state;
 mod state_machine;
 mod superstate;
 
-pub use crate::Response::{self, *};
+pub use crate::Outcome::{self, *};
 pub use crate::*;
 
 pub(crate) use inner::*;

--- a/statig/src/blocking/state.rs
+++ b/statig/src/blocking/state.rs
@@ -1,5 +1,5 @@
 use crate::blocking::{IntoStateMachine, Superstate, SuperstateExt};
-use crate::{Response, StateOrSuperstate};
+use crate::{Outcome, StateOrSuperstate};
 
 /// An enum that represents the leaf states of the state machine.
 pub trait State<M>
@@ -13,7 +13,7 @@ where
         shared_storage: &mut M,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) -> Response<Self>;
+    ) -> Outcome<Self>;
 
     #[allow(unused)]
     /// Call the entry action for the current state.
@@ -89,7 +89,7 @@ where
         shared_storage: &mut M,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) -> Response<Self>
+    ) -> Outcome<Self>
     where
         Self: Sized,
     {
@@ -100,8 +100,8 @@ where
         M::after_dispatch(shared_storage, StateOrSuperstate::State(self), event);
 
         match response {
-            Response::Handled => Response::Handled,
-            Response::Super => match self.superstate() {
+            Outcome::Handled => Outcome::Handled,
+            Outcome::Super => match self.superstate() {
                 Some(mut superstate) => {
                     M::before_dispatch(
                         shared_storage,
@@ -119,9 +119,9 @@ where
 
                     response
                 }
-                None => Response::Super,
+                None => Outcome::Super,
             },
-            Response::Transition(state) => Response::Transition(state),
+            Outcome::Transition(state) => Outcome::Transition(state),
         }
     }
 

--- a/statig/src/blocking/state_machine.rs
+++ b/statig/src/blocking/state_machine.rs
@@ -128,7 +128,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let state_machine = Blinky::default().state_machine();
@@ -157,7 +157,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let mut state_machine = Blinky::default().state_machine();
@@ -189,7 +189,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let mut state_machine = Blinky::default().state_machine();
@@ -376,7 +376,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -406,7 +406,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -438,7 +438,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -571,7 +571,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -605,7 +605,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -640,7 +640,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -665,7 +665,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -695,7 +695,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Response<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
     /// # }
     /// #
     /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();

--- a/statig/src/blocking/superstate.rs
+++ b/statig/src/blocking/superstate.rs
@@ -1,7 +1,7 @@
 use core::cmp::Ordering;
 
 use crate::blocking::IntoStateMachine;
-use crate::{Response, StateOrSuperstate};
+use crate::{Outcome, StateOrSuperstate};
 
 /// An enum that represents the superstates of the state machine.
 pub trait Superstate<M>
@@ -14,7 +14,7 @@ where
         shared_storage: &mut M,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) -> Response<M::State>;
+    ) -> Outcome<M::State>;
 
     #[allow(unused)]
     /// Call the entry action for the current superstate.
@@ -92,15 +92,15 @@ where
         shared_storage: &mut M,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) -> Response<M::State>
+    ) -> Outcome<M::State>
     where
         Self: Sized,
     {
         let response = self.call_handler(shared_storage, event, context);
 
         match response {
-            Response::Handled => Response::Handled,
-            Response::Super => match self.superstate() {
+            Outcome::Handled => Outcome::Handled,
+            Outcome::Super => match self.superstate() {
                 Some(mut superstate) => {
                     M::before_dispatch(
                         shared_storage,
@@ -118,9 +118,9 @@ where
 
                     response
                 }
-                None => Response::Super,
+                None => Outcome::Super,
             },
-            Response::Transition(state) => Response::Transition(state),
+            Outcome::Transition(state) => Outcome::Transition(state),
         }
     }
 
@@ -167,8 +167,8 @@ where
         _: &mut M,
         _: &M::Event<'_>,
         _: &mut M::Context<'_>,
-    ) -> Response<M::State> {
-        Response::Handled
+    ) -> Outcome<M::State> {
+        Outcome::Handled
     }
 
     fn call_entry_action(&mut self, _: &mut M, _: &mut M::Context<'_>) {}

--- a/statig/src/lib.rs
+++ b/statig/src/lib.rs
@@ -152,7 +152,7 @@ pub mod prelude {
     #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
     pub use crate::awaitable::{IntoStateMachineExt as _, StateExt as _, *};
     pub use crate::blocking::{IntoStateMachineExt as _, StateExt as _, *};
-    pub use crate::Response::{self, *};
+    pub use crate::Outcome::{self, *};
     pub use crate::StateOrSuperstate;
     #[cfg(feature = "macro")]
     #[cfg_attr(docsrs, doc(cfg(feature = "macro")))]

--- a/statig/src/response.rs
+++ b/statig/src/response.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
-/// Response returned by event handlers in a state machine.
-pub enum Response<S> {
+/// Outcome returned by event handlers in a state machine.
+pub enum Outcome<S> {
     /// Consider the event handled.
     Handled,
     /// Defer the event to the superstate.
@@ -10,7 +10,10 @@ pub enum Response<S> {
     Transition(S),
 }
 
-impl<S> PartialEq for Response<S>
+#[deprecated(since = "0.4", note = "`Response` has been renamed to `Outcome`")]
+pub type Response<S> = Outcome<S>;
+
+impl<S> PartialEq for Outcome<S>
 where
     S: PartialEq,
 {
@@ -24,9 +27,9 @@ where
     }
 }
 
-impl<S> Eq for Response<S> where S: Eq {}
+impl<S> Eq for Outcome<S> where S: Eq {}
 
-impl<S> Debug for Response<S>
+impl<S> Debug for Outcome<S>
 where
     S: Debug,
 {

--- a/statig/tests/async_hooks.rs
+++ b/statig/tests/async_hooks.rs
@@ -26,12 +26,12 @@ mod tests {
     )]
     impl FooBar {
         #[state]
-        async fn foo(event: &Event) -> Response<State> {
+        async fn foo(event: &Event) -> Outcome<State> {
             Transition(State::bar())
         }
 
         #[state]
-        async fn bar(event: &Event) -> Response<State> {
+        async fn bar(event: &Event) -> Outcome<State> {
             Transition(State::foo())
         }
     }

--- a/statig/tests/async_transition.rs
+++ b/statig/tests/async_transition.rs
@@ -7,7 +7,7 @@ mod tests {
     use statig::awaitable::{self, *};
     use std::fmt;
 
-    type Response = statig::Response<State>;
+    type Outcome = statig::Outcome<State>;
 
     #[derive(Clone)]
     enum Event {
@@ -69,7 +69,7 @@ mod tests {
             shared_storage: &mut Foo,
             event: &<Foo as IntoStateMachine>::Event<'_>,
             _: &mut <Foo as IntoStateMachine>::Context<'_>,
-        ) -> impl Future<Output = statig::Response<Self>> {
+        ) -> impl Future<Output = statig::Outcome<Self>> {
             async move {
                 match self {
                     State::S211 {} => Foo::s211(shared_storage, event).await,
@@ -122,7 +122,7 @@ mod tests {
             shared_storage: &mut Foo,
             event: &<Foo as IntoStateMachine>::Event<'_>,
             _: &mut <Foo as IntoStateMachine>::Context<'_>,
-        ) -> impl Future<Output = statig::Response<State>>
+        ) -> impl Future<Output = statig::Outcome<State>>
         where
             Self: Sized,
         {
@@ -178,7 +178,7 @@ mod tests {
 
     impl Foo {
         /// s11
-        pub async fn s11(&mut self, event: &Event) -> Response {
+        pub async fn s11(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::A => Transition(State::S11),
                 Event::B => Transition(State::S12),
@@ -197,7 +197,7 @@ mod tests {
         }
 
         /// s12
-        async fn s12(&mut self, event: &Event) -> Response {
+        async fn s12(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::C => Transition(State::S211),
                 _ => Super,
@@ -216,7 +216,7 @@ mod tests {
 
         /// s1
         #[allow(unused)]
-        async fn s1(&mut self, event: &Event) -> Response {
+        async fn s1(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -232,7 +232,7 @@ mod tests {
 
         /// s211
         #[allow(unused)]
-        async fn s211(&mut self, event: &Event) -> Response {
+        async fn s211(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -248,7 +248,7 @@ mod tests {
 
         /// s21
         #[allow(unused)]
-        pub async fn s21(&mut self, event: &Event) -> Response {
+        pub async fn s21(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -263,7 +263,7 @@ mod tests {
         }
 
         /// s2
-        pub async fn s2(&mut self, event: &Event) -> Response {
+        pub async fn s2(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::D => Transition(State::S11),
                 _ => Super,
@@ -282,7 +282,7 @@ mod tests {
 
         /// s
         #[allow(unused)]
-        async fn s(&mut self, event: &Event) -> Response {
+        async fn s(&mut self, event: &Event) -> Outcome {
             Handled
         }
 

--- a/statig/tests/async_transition_macro.rs
+++ b/statig/tests/async_transition_macro.rs
@@ -5,7 +5,7 @@ mod tests {
     use statig::prelude::*;
     use std::fmt;
 
-    type Response = statig::Response<State>;
+    type Outcome = statig::Outcome<State>;
 
     #[derive(Clone, Debug)]
     enum Event {
@@ -45,7 +45,7 @@ mod tests {
             entry_action = "enter_s11",
             exit_action = "exit_s11"
         )]
-        pub async fn s11(&mut self, event: &Event) -> Response {
+        pub async fn s11(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::A => Transition(State::s11()),
                 Event::B => Transition(State::s12()),
@@ -71,7 +71,7 @@ mod tests {
             entry_action = "enter_s12",
             exit_action = "exit_s12"
         )]
-        pub async fn s12(&mut self, event: &Event) -> Response {
+        pub async fn s12(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::C => Transition(State::s211()),
                 _ => Super,
@@ -93,7 +93,7 @@ mod tests {
         /// s1
         #[allow(unused)]
         #[superstate(superstate = "s", entry_action = "enter_s1", exit_action = "exit_s1")]
-        pub async fn s1(&mut self, event: &Event) -> Response {
+        pub async fn s1(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -116,7 +116,7 @@ mod tests {
             entry_action = "enter_s211",
             exit_action = "exit_s211"
         )]
-        pub async fn s211(&mut self, event: &Event) -> Response {
+        pub async fn s211(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -139,7 +139,7 @@ mod tests {
             entry_action = "enter_s21",
             exit_action = "exit_s21"
         )]
-        pub async fn s21(&mut self, event: &Event) -> Response {
+        pub async fn s21(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -157,7 +157,7 @@ mod tests {
 
         /// s2
         #[superstate(superstate = "s", entry_action = "enter_s2", exit_action = "exit_s2")]
-        pub async fn s2(&mut self, event: &Event) -> Response {
+        pub async fn s2(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::D => Transition(State::s11()),
                 _ => Super,
@@ -179,7 +179,7 @@ mod tests {
         /// s
         #[allow(unused)]
         #[superstate(entry_action = "enter_s", exit_action = "exit_s")]
-        pub async fn s(&mut self, event: &Event) -> Response {
+        pub async fn s(&mut self, event: &Event) -> Outcome {
             Handled
         }
 

--- a/statig/tests/config_macro.rs
+++ b/statig/tests/config_macro.rs
@@ -27,14 +27,14 @@ mod tests {
         )]
         impl MyStateMachine {
             #[state(superstate = "foo")]
-            fn bar(my_event: &Event, my_context: &mut Context) -> Response<MyState> {
+            fn bar(my_event: &Event, my_context: &mut Context) -> Outcome<MyState> {
                 match my_event {
                     Event::A => Handled,
                 }
             }
 
             #[superstate]
-            fn foo(my_event: &Event, my_context: &mut Context) -> Response<MyState> {
+            fn foo(my_event: &Event, my_context: &mut Context) -> Outcome<MyState> {
                 match my_event {
                     Event::A => Handled,
                 }

--- a/statig/tests/default.rs
+++ b/statig/tests/default.rs
@@ -12,7 +12,7 @@ mod tests {
         fn bar(
             #[default] local: &mut usize,
             #[default = "100"] local_2: &mut usize,
-        ) -> Response<State> {
+        ) -> Outcome<State> {
             Handled
         }
     }

--- a/statig/tests/external_context.rs
+++ b/statig/tests/external_context.rs
@@ -16,7 +16,7 @@ mod tests {
     #[state_machine(initial = "State::up()")]
     impl Counter {
         #[state]
-        fn up(context: &mut ExternalContext<'_, '_>, event: &Event) -> Response<State> {
+        fn up(context: &mut ExternalContext<'_, '_>, event: &Event) -> Outcome<State> {
             match event {
                 Event::ButtonPressed => {
                     *context.0 = context.0.saturating_add(1);
@@ -27,7 +27,7 @@ mod tests {
         }
 
         #[state]
-        fn down(context: &mut ExternalContext<'_, '_>, event: &Event) -> Response<State> {
+        fn down(context: &mut ExternalContext<'_, '_>, event: &Event) -> Outcome<State> {
             match event {
                 Event::ButtonPressed => {
                     *context.0 = context.0.saturating_sub(1);

--- a/statig/tests/generics.rs
+++ b/statig/tests/generics.rs
@@ -25,17 +25,17 @@ mod tests {
         B: 'static,
     {
         #[state]
-        fn a() -> Response<State<T, B, SIZE>> {
+        fn a() -> Outcome<State<T, B, SIZE>> {
             Handled
         }
 
         #[state]
-        fn b(array: &mut [T; SIZE]) -> Response<State<T, B, SIZE>> {
+        fn b(array: &mut [T; SIZE]) -> Outcome<State<T, B, SIZE>> {
             Handled
         }
 
         #[state]
-        fn c(deref: &B) -> Response<State<T, B, SIZE>> {
+        fn c(deref: &B) -> Outcome<State<T, B, SIZE>> {
             Handled
         }
     }

--- a/statig/tests/hooks.rs
+++ b/statig/tests/hooks.rs
@@ -25,12 +25,12 @@ mod tests {
     )]
     impl FooBar {
         #[state]
-        fn foo(event: &Event) -> Response<State> {
+        fn foo(event: &Event) -> Outcome<State> {
             Transition(State::bar())
         }
 
         #[state]
-        fn bar(event: &Event) -> Response<State> {
+        fn bar(event: &Event) -> Outcome<State> {
             Transition(State::foo())
         }
     }

--- a/statig/tests/serde.rs
+++ b/statig/tests/serde.rs
@@ -28,7 +28,7 @@ fn serialize_deserialize() {
     )]
     impl Blinky {
         #[state(superstate = "blinking")]
-        fn led_on(event: &Event) -> Response<State> {
+        fn led_on(event: &Event) -> Outcome<State> {
             match event {
                 Event::TimerElapsed => Transition(State::led_off()),
                 _ => Super,
@@ -36,7 +36,7 @@ fn serialize_deserialize() {
         }
 
         #[state(superstate = "blinking")]
-        fn led_off(event: &Event) -> Response<State> {
+        fn led_off(event: &Event) -> Outcome<State> {
             match event {
                 Event::TimerElapsed => Transition(State::led_on()),
                 _ => Super,
@@ -44,7 +44,7 @@ fn serialize_deserialize() {
         }
 
         #[superstate]
-        fn blinking(event: &Event) -> Response<State> {
+        fn blinking(event: &Event) -> Outcome<State> {
             match event {
                 Event::ButtonPressed => Transition(State::not_blinking()),
                 _ => Super,
@@ -52,7 +52,7 @@ fn serialize_deserialize() {
         }
 
         #[state]
-        fn not_blinking(event: &Event) -> Response<State> {
+        fn not_blinking(event: &Event) -> Outcome<State> {
             match event {
                 Event::ButtonPressed => Transition(State::led_on()),
                 _ => Super,

--- a/statig/tests/state_local_storage.rs
+++ b/statig/tests/state_local_storage.rs
@@ -38,7 +38,7 @@ mod tests {
     struct Event;
 
     impl Blinky {
-        fn on(&mut self, led: &mut bool, counter: &mut isize, event: &Event) -> Response<State> {
+        fn on(&mut self, led: &mut bool, counter: &mut isize, event: &Event) -> Outcome<State> {
             Transition(State::off(false))
         }
 
@@ -47,11 +47,11 @@ mod tests {
             *led = false;
         }
 
-        fn off(&mut self, led: &mut bool, event: &Event) -> Response<State> {
+        fn off(&mut self, led: &mut bool, event: &Event) -> Outcome<State> {
             Transition(State::on(true, 34))
         }
 
-        fn playing(&mut self, led: &mut bool) -> Response<State> {
+        fn playing(&mut self, led: &mut bool) -> Outcome<State> {
             Handled
         }
     }
@@ -77,7 +77,7 @@ mod tests {
             shared_storage: &mut Blinky,
             event: &Event,
             _: &mut (),
-        ) -> Response<State>
+        ) -> Outcome<State>
         where
             Self: Sized,
         {
@@ -125,7 +125,7 @@ mod tests {
             shared_storage: &mut Blinky,
             event: &Event,
             _: &mut (),
-        ) -> Response<State> {
+        ) -> Outcome<State> {
             match self {
                 Superstate::Playing { led } => Blinky::playing(shared_storage, led),
             }

--- a/statig/tests/state_local_storage_macro.rs
+++ b/statig/tests/state_local_storage_macro.rs
@@ -14,7 +14,7 @@ mod tests {
     #[state_machine(initial = "Superstate::playing()")]
     impl Blinky {
         #[state]
-        fn on(&mut self, led: &mut bool, counter: &mut isize, event: &Event) -> Response<State> {
+        fn on(&mut self, led: &mut bool, counter: &mut isize, event: &Event) -> Outcome<State> {
             Transition(State::off(false))
         }
 
@@ -25,12 +25,12 @@ mod tests {
         }
 
         #[state(entry_action = "enter_off")]
-        fn off(&mut self, led: &mut bool, event: &Event) -> Response<State> {
+        fn off(&mut self, led: &mut bool, event: &Event) -> Outcome<State> {
             Transition(State::on(true, 34))
         }
 
         #[superstate(initial = "State::on(false, 23)")]
-        fn playing(&mut self, led: &mut bool) -> Response<State> {
+        fn playing(&mut self, led: &mut bool) -> Outcome<State> {
             Handled
         }
     }

--- a/statig/tests/transition.rs
+++ b/statig/tests/transition.rs
@@ -4,7 +4,7 @@ mod tests {
     use statig::blocking::{self, *};
     use std::fmt;
 
-    type Response = statig::Response<State>;
+    type Outcome = statig::Outcome<State>;
 
     #[derive(Clone)]
     enum Event {
@@ -66,7 +66,7 @@ mod tests {
             shared_storage: &mut Foo,
             event: &Event,
             _: &mut (),
-        ) -> statig::Response<Self> {
+        ) -> statig::Outcome<Self> {
             match self {
                 State::S211 {} => Foo::s211(shared_storage, event),
                 State::S11 {} => Foo::s11(shared_storage, event),
@@ -108,7 +108,7 @@ mod tests {
             shared_storage: &mut Foo,
             event: &Event,
             _: &mut (),
-        ) -> statig::Response<State>
+        ) -> statig::Outcome<State>
         where
             Self: Sized,
         {
@@ -150,7 +150,7 @@ mod tests {
 
     impl Foo {
         /// s11
-        pub fn s11(&mut self, event: &Event) -> Response {
+        pub fn s11(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::A => Transition(State::S11),
                 Event::B => Transition(State::S12),
@@ -169,7 +169,7 @@ mod tests {
         }
 
         /// s12
-        pub fn s12(&mut self, event: &Event) -> Response {
+        pub fn s12(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::C => Transition(State::S211),
                 _ => Super,
@@ -188,7 +188,7 @@ mod tests {
 
         /// s1
         #[allow(unused)]
-        pub fn s1(&mut self, event: &Event) -> Response {
+        pub fn s1(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -204,7 +204,7 @@ mod tests {
 
         /// s211
         #[allow(unused)]
-        pub fn s211(&mut self, event: &Event) -> Response {
+        pub fn s211(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -220,7 +220,7 @@ mod tests {
 
         /// s21
         #[allow(unused)]
-        pub fn s21(&mut self, event: &Event) -> Response {
+        pub fn s21(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -235,7 +235,7 @@ mod tests {
         }
 
         /// s2
-        pub fn s2(&mut self, event: &Event) -> Response {
+        pub fn s2(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::D => Transition(State::S11),
                 _ => Super,
@@ -254,7 +254,7 @@ mod tests {
 
         /// s
         #[allow(unused)]
-        pub fn s(&mut self, event: &Event) -> Response {
+        pub fn s(&mut self, event: &Event) -> Outcome {
             Handled
         }
 

--- a/statig/tests/transition_macro.rs
+++ b/statig/tests/transition_macro.rs
@@ -4,7 +4,7 @@ mod tests {
     use statig::blocking::*;
     use std::fmt;
 
-    type Response = statig::Response<State>;
+    type Outcome = statig::Outcome<State>;
 
     #[derive(Clone, Debug)]
     enum Event {
@@ -44,7 +44,7 @@ mod tests {
             entry_action = "enter_s11",
             exit_action = "exit_s11"
         )]
-        pub fn s11(&mut self, event: &Event) -> Response {
+        pub fn s11(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::A => Transition(State::s11()),
                 Event::B => Transition(State::s12()),
@@ -70,7 +70,7 @@ mod tests {
             entry_action = "enter_s12",
             exit_action = "exit_s12"
         )]
-        pub fn s12(&mut self, event: &Event) -> Response {
+        pub fn s12(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::C => Transition(State::s211()),
                 _ => Super,
@@ -92,7 +92,7 @@ mod tests {
         /// s1
         #[allow(unused)]
         #[superstate(superstate = "s", entry_action = "enter_s1", exit_action = "exit_s1")]
-        pub fn s1(&mut self, event: &Event) -> Response {
+        pub fn s1(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -115,7 +115,7 @@ mod tests {
             entry_action = "enter_s211",
             exit_action = "exit_s211"
         )]
-        pub fn s211(&mut self, event: &Event) -> Response {
+        pub fn s211(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -138,7 +138,7 @@ mod tests {
             entry_action = "enter_s21",
             exit_action = "exit_s21"
         )]
-        pub fn s21(&mut self, event: &Event) -> Response {
+        pub fn s21(&mut self, event: &Event) -> Outcome {
             Super
         }
 
@@ -156,7 +156,7 @@ mod tests {
 
         /// s2
         #[superstate(superstate = "s", entry_action = "enter_s2", exit_action = "exit_s2")]
-        pub fn s2(&mut self, event: &Event) -> Response {
+        pub fn s2(&mut self, event: &Event) -> Outcome {
             match event {
                 Event::D => Transition(State::s11()),
                 _ => Super,
@@ -178,7 +178,7 @@ mod tests {
         /// s
         #[allow(unused)]
         #[superstate(entry_action = "enter_s", exit_action = "exit_s")]
-        pub fn s(&mut self, event: &Event) -> Response {
+        pub fn s(&mut self, event: &Event) -> Outcome {
             Handled
         }
 

--- a/statig/tests/ui/custom_state.rs
+++ b/statig/tests/ui/custom_state.rs
@@ -35,12 +35,12 @@ impl CustomState {
 )]
 impl Blinky {
     #[state]
-    fn led_on(event: &Event) -> Response<CustomState> {
+    fn led_on(event: &Event) -> Outcome<CustomState> {
         Transition(CustomState::led_off())
     }
 
     #[state]
-    fn led_off(event: &Event) -> Response<CustomState> {
+    fn led_off(event: &Event) -> Outcome<CustomState> {
         Transition(CustomState::led_on())
     }
 }

--- a/statig/tests/ui/custom_state_derive_error.rs
+++ b/statig/tests/ui/custom_state_derive_error.rs
@@ -35,12 +35,12 @@ impl CustomState {
 )]
 impl Blinky {
     #[state]
-    fn led_on(event: &Event) -> Response<CustomState> {
+    fn led_on(event: &Event) -> Outcome<CustomState> {
         Transition(CustomState::led_off())
     }
 
     #[state]
-    fn led_off(event: &Event) -> Response<CustomState> {
+    fn led_off(event: &Event) -> Outcome<CustomState> {
         Transition(CustomState::led_on())
     }
 }


### PR DESCRIPTION
Naming is hard and I've slowly come to the conclusion that using `Response` for state handlers output wasn't the best choice. The term "response" is already very common within programming and often implies an associated "request", which isn't the case in statig. I've also found myself in situations where I wanted to store (application-level) requests within local-storage, which resulted in function signatures like this:

```rust
#[state]
fn processing(&mut self, request: Request, event: &Event) -> Response<State> { ... }
```

Readers of this signature would be forgiven for thinking `Request` and `Response` are somehow associated with each other, even though this isn't the case.

After some consideration (and consulting of thesaurus.com) I've landed on `Outcome`. I think it is a more natural fit to the state machine terminology (an "event" produces an "outcome") and isn't something that would cause other conflicts (i.e. something like `Result`). 

This is a breaking change, but to make the transition as pain-free as possible I've provided a `Response` type alias that is marked as deprecated and can be removed in some future release.

