### PR TITLE
Make context parameter optional in hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ The association between states and their handlers is then expressed in the `Stat
 
 ```rust
 impl statig::State<Blinky> for State {
-    fn call_handler(&mut self, blinky: &mut Blinky, event: &Event) -> Outcome<Self> {
+    fn call_handler(&mut self, blinky: &mut Blinky, event: &Event, context: &mut ()) -> Outcome<Self> {
         match self {
             State::LedOn { counter } => blinky.led_on(counter, event),
             State::LedOff { counter } => blinky.led_off(counter, event),
@@ -379,7 +379,7 @@ impl statig::State<Blinky> for State {
 }
 
 impl statig::Superstate<Blinky> for Superstate {
-    fn call_handler(&mut self, blinky: &mut Blinky, event: &Event) -> Outcome<Self> {
+    fn call_handler(&mut self, blinky: &mut Blinky, event: &Event, context: &mut ()) -> Outcome<Self> {
         match self {
             Superstate::Blinking { counter } => blinky.blinking(counter, event),
         }
@@ -394,7 +394,7 @@ impl statig::State<Blinky> for State {
 
     ...
 
-    fn call_entry_action(&mut self, blinky: &mut Blinky) {
+    fn call_entry_action(&mut self, blinky: &mut Blinky, context: &mut ()) {
         match self {
             State::LedOn { counter } => blinky.enter_led_on(counter),
             State::LedOff { counter } => blinky.enter_led_off(counter),
@@ -402,7 +402,7 @@ impl statig::State<Blinky> for State {
         }
     }
 
-    fn call_exit_action(&mut self, blinky: &mut Blinky) {
+    fn call_exit_action(&mut self, blinky: &mut Blinky, context: &mut ()) {
         match self {
             State::LedOn { counter } => blinky.exit_led_on(counter),
             State::LedOff { counter } => blinky.exit_led_off(counter),
@@ -415,13 +415,13 @@ impl statig::Superstate<Blinky> for Superstate {
 
     ...
 
-    fn call_entry_action(&mut self, blinky: &mut Blinky) {
+    fn call_entry_action(&mut self, blinky: &mut Blinky, context: &mut ()) {
         match self {
             Superstate::Blinking { counter } => blinky.enter_blinking(counter),
         }
     }
 
-    fn call_exit_action(&mut self, blinky: &mut Blinky) {
+    fn call_exit_action(&mut self, blinky: &mut Blinky, context: &mut ()) {
         match self {
             Superstate::Blinking { counter } => blinky.exit_blinking(counter),
         }
@@ -490,7 +490,9 @@ impl IntoStateMachine for Blinky {
 
     type Context<'ctx> = Context;
 
-    const INITIAL: fn() -> State = || State::off(10);
+    fn initial() -> Self::State {
+        State::off(10)
+    }
 }
 ```
 

--- a/macro/src/analyze.rs
+++ b/macro/src/analyze.rs
@@ -645,6 +645,9 @@ pub fn analyze_superstate(method: &ImplItemFn, state_machine: &StateMachine) -> 
                 Err(_) => abort!(meta, "initial state must be an expression"),
             }
         } else if meta.path().is_ident("local_storage") {
+            if !local_storage.is_empty() {
+                abort!(meta, "duplicate `local_storage` item")
+            }
             match meta.require_list().and_then(|list| {
                 Punctuated::<LitStr, Token![,]>::parse_terminated.parse2(list.tokens.clone())
             }) {

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -69,7 +69,8 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     event: &Self::Event<'_>,
                     context: &mut Self::Context<'_>,
                 ) {
-                    #before_dispatch(self, state_or_superstate, event, context);
+                    use statig::blocking::DispatchHook;
+                    #before_dispatch.call_dispatch_hook(self, state_or_superstate, event, context);
                 }
             ),
             Mode::Awaitable => quote!(
@@ -79,7 +80,8 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     event: &Self::Event<'_>,
                     context: &mut Self::Context<'_>,
                 ) -> impl core::future::Future<Output = ()> {
-                    #before_dispatch(self, state_or_superstate, event, context)
+                    use statig::awaitable::DispatchHook;
+                    #before_dispatch.call_dispatch_hook(self, state_or_superstate, event, context)
                 }
             ),
         },
@@ -95,7 +97,8 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     event: &Self::Event<'_>,
                     context: &mut Self::Context<'_>,
                 ) {
-                    #after_dispatch(self, state_or_superstate, event, context);
+                    use statig::blocking::DispatchHook;
+                    #after_dispatch.call_dispatch_hook(self, state_or_superstate, event, context);
                 }
             ),
             Mode::Awaitable => quote!(
@@ -105,7 +108,8 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     event: &Self::Event<'_>,
                     context: &mut Self::Context<'_>,
                 ) -> impl core::future::Future<Output = ()> {
-                    #after_dispatch(self, state_or_superstate, event, context)
+                    use statig::awaitable::DispatchHook;
+                    #after_dispatch.call_dispatch_hook(self, state_or_superstate, event, context)
                 }
             ),
         },
@@ -121,7 +125,8 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     target: &Self::State,
                     context: &mut Self::Context<'_>,
                 ) {
-                    #before_transition(self, source, target, context);
+                    use statig::blocking::TransitionHook;
+                    #before_transition.call_transition_hook(self, source, target, context);
                 }
             ),
             Mode::Awaitable => quote!(
@@ -131,7 +136,8 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     target: &Self::State,
                     context: &mut Self::Context<'_>,
                 ) -> impl core::future::Future<Output = ()> {
-                    #before_transition(self, source, target, context)
+                    use statig::awaitable::TransitionHook;
+                    #before_transition.call_transition_hook(self, source, target, context)
                 }
             ),
         },
@@ -147,7 +153,8 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     target: &Self::State,
                     context: &mut Self::Context<'_>,
                 ) {
-                    #after_transition(self, source, target, context);
+                    use statig::blocking::TransitionHook;
+                    #after_transition.call_transition_hook(self, source, target, context);
                 }
             ),
             Mode::Awaitable => quote!(
@@ -157,7 +164,8 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
                     target: &Self::State,
                     context: &mut Self::Context<'_>,
                 ) -> impl core::future::Future<Output = ()> {
-                    #after_transition(self, source, target, context)
+                    use statig::awaitable::TransitionHook;
+                    #after_transition.call_transition_hook(self, source, target, context)
                 }
             ),
         },

--- a/statig/tests/async_hooks.rs
+++ b/statig/tests/async_hooks.rs
@@ -41,7 +41,6 @@ mod tests {
             &mut self,
             state_or_superstate: StateOrSuperstate<'_, State, Superstate>,
             event: &Event,
-            _context: &mut (),
         ) {
             self.before_dispatch = true;
         }
@@ -55,7 +54,7 @@ mod tests {
             self.after_dispatch = true;
         }
 
-        async fn before_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
+        async fn before_transition(&mut self, source: &State, target: &State) {
             self.before_transition = true;
         }
 

--- a/statig/tests/hooks.rs
+++ b/statig/tests/hooks.rs
@@ -40,7 +40,6 @@ mod tests {
             &mut self,
             state_or_superstate: StateOrSuperstate<'_, State, Superstate>,
             event: &Event,
-            _context: &mut (),
         ) {
             self.before_dispatch = true;
         }
@@ -54,7 +53,7 @@ mod tests {
             self.after_dispatch = true;
         }
 
-        fn before_transition(&mut self, source: &State, target: &State, _context: &mut ()) {
+        fn before_transition(&mut self, source: &State, target: &State) {
             self.before_transition = true;
         }
 


### PR DESCRIPTION
Give users the ability to pass hooks both with and without the context parameter when using the macro.