### PR TITLE
Event responses

### DIFF
--- a/examples/macro/async_bench_complex/src/main.rs
+++ b/examples/macro/async_bench_complex/src/main.rs
@@ -64,7 +64,7 @@ impl BenchComplex {
     async fn idle(event: &Event) -> Outcome<State> {
         match event {
             Event::E1 => Transition(State::s2()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -72,7 +72,7 @@ impl BenchComplex {
     async fn s1(event: &Event) -> Outcome<State> {
         match event {
             Event::E2 => Transition(State::s2()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -80,7 +80,7 @@ impl BenchComplex {
     async fn s2(event: &Event) -> Outcome<State> {
         match event {
             Event::E3 => Transition(State::s3()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -88,7 +88,7 @@ impl BenchComplex {
     async fn s3(event: &Event) -> Outcome<State> {
         match event {
             Event::E4 => Transition(State::s4()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -96,7 +96,7 @@ impl BenchComplex {
     async fn s4(event: &Event) -> Outcome<State> {
         match event {
             Event::E5 => Transition(State::s5()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -104,7 +104,7 @@ impl BenchComplex {
     async fn s5(event: &Event) -> Outcome<State> {
         match event {
             Event::E6 => Transition(State::s6()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -112,7 +112,7 @@ impl BenchComplex {
     async fn s6(event: &Event) -> Outcome<State> {
         match event {
             Event::E7 => Transition(State::s7()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -120,7 +120,7 @@ impl BenchComplex {
     async fn s7(event: &Event) -> Outcome<State> {
         match event {
             Event::E8 => Transition(State::s8()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -128,7 +128,7 @@ impl BenchComplex {
     async fn s8(event: &Event) -> Outcome<State> {
         match event {
             Event::E9 => Transition(State::s9()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -136,7 +136,7 @@ impl BenchComplex {
     async fn s9(event: &Event) -> Outcome<State> {
         match event {
             Event::E10 => Transition(State::s10()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -144,7 +144,7 @@ impl BenchComplex {
     async fn s10(event: &Event) -> Outcome<State> {
         match event {
             Event::E11 => Transition(State::s11()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -152,7 +152,7 @@ impl BenchComplex {
     async fn s11(event: &Event) -> Outcome<State> {
         match event {
             Event::E12 => Transition(State::s12()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -160,7 +160,7 @@ impl BenchComplex {
     async fn s12(event: &Event) -> Outcome<State> {
         match event {
             Event::E13 => Transition(State::s13()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -168,7 +168,7 @@ impl BenchComplex {
     async fn s13(event: &Event) -> Outcome<State> {
         match event {
             Event::E14 => Transition(State::s14()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -176,7 +176,7 @@ impl BenchComplex {
     async fn s14(event: &Event) -> Outcome<State> {
         match event {
             Event::E15 => Transition(State::s15()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -184,7 +184,7 @@ impl BenchComplex {
     async fn s15(event: &Event) -> Outcome<State> {
         match event {
             Event::E16 => Transition(State::s16()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -192,7 +192,7 @@ impl BenchComplex {
     async fn s16(event: &Event) -> Outcome<State> {
         match event {
             Event::E17 => Transition(State::s17()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -200,7 +200,7 @@ impl BenchComplex {
     async fn s17(event: &Event) -> Outcome<State> {
         match event {
             Event::E18 => Transition(State::s18()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -208,7 +208,7 @@ impl BenchComplex {
     async fn s18(event: &Event) -> Outcome<State> {
         match event {
             Event::E19 => Transition(State::s19()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -216,7 +216,7 @@ impl BenchComplex {
     async fn s19(event: &Event) -> Outcome<State> {
         match event {
             Event::E20 => Transition(State::s20()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -224,7 +224,7 @@ impl BenchComplex {
     async fn s20(event: &Event) -> Outcome<State> {
         match event {
             Event::E21 => Transition(State::s21()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -232,7 +232,7 @@ impl BenchComplex {
     async fn s21(event: &Event) -> Outcome<State> {
         match event {
             Event::E22 => Transition(State::s22()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -240,7 +240,7 @@ impl BenchComplex {
     async fn s22(event: &Event) -> Outcome<State> {
         match event {
             Event::E23 => Transition(State::s23()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -248,7 +248,7 @@ impl BenchComplex {
     async fn s23(event: &Event) -> Outcome<State> {
         match event {
             Event::E24 => Transition(State::s24()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -256,7 +256,7 @@ impl BenchComplex {
     async fn s24(event: &Event) -> Outcome<State> {
         match event {
             Event::E25 => Transition(State::s25()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -264,7 +264,7 @@ impl BenchComplex {
     async fn s25(event: &Event) -> Outcome<State> {
         match event {
             Event::E26 => Transition(State::s26()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -272,7 +272,7 @@ impl BenchComplex {
     async fn s26(event: &Event) -> Outcome<State> {
         match event {
             Event::E27 => Transition(State::s27()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -280,7 +280,7 @@ impl BenchComplex {
     async fn s27(event: &Event) -> Outcome<State> {
         match event {
             Event::E28 => Transition(State::s28()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -288,7 +288,7 @@ impl BenchComplex {
     async fn s28(event: &Event) -> Outcome<State> {
         match event {
             Event::E29 => Transition(State::s29()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -296,7 +296,7 @@ impl BenchComplex {
     async fn s29(event: &Event) -> Outcome<State> {
         match event {
             Event::E30 => Transition(State::s30()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -304,7 +304,7 @@ impl BenchComplex {
     async fn s30(event: &Event) -> Outcome<State> {
         match event {
             Event::E31 => Transition(State::s31()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -312,7 +312,7 @@ impl BenchComplex {
     async fn s31(event: &Event) -> Outcome<State> {
         match event {
             Event::E32 => Transition(State::s32()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -320,7 +320,7 @@ impl BenchComplex {
     async fn s32(event: &Event) -> Outcome<State> {
         match event {
             Event::E33 => Transition(State::s33()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -328,7 +328,7 @@ impl BenchComplex {
     async fn s33(event: &Event) -> Outcome<State> {
         match event {
             Event::E34 => Transition(State::s34()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -336,7 +336,7 @@ impl BenchComplex {
     async fn s34(event: &Event) -> Outcome<State> {
         match event {
             Event::E35 => Transition(State::s35()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -344,7 +344,7 @@ impl BenchComplex {
     async fn s35(event: &Event) -> Outcome<State> {
         match event {
             Event::E36 => Transition(State::s36()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -352,7 +352,7 @@ impl BenchComplex {
     async fn s36(event: &Event) -> Outcome<State> {
         match event {
             Event::E37 => Transition(State::s37()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -360,7 +360,7 @@ impl BenchComplex {
     async fn s37(event: &Event) -> Outcome<State> {
         match event {
             Event::E38 => Transition(State::s38()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -368,7 +368,7 @@ impl BenchComplex {
     async fn s38(event: &Event) -> Outcome<State> {
         match event {
             Event::E39 => Transition(State::s39()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -376,7 +376,7 @@ impl BenchComplex {
     async fn s39(event: &Event) -> Outcome<State> {
         match event {
             Event::E40 => Transition(State::s40()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -384,7 +384,7 @@ impl BenchComplex {
     async fn s40(event: &Event) -> Outcome<State> {
         match event {
             Event::E41 => Transition(State::s41()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -392,7 +392,7 @@ impl BenchComplex {
     async fn s41(event: &Event) -> Outcome<State> {
         match event {
             Event::E42 => Transition(State::s42()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -400,7 +400,7 @@ impl BenchComplex {
     async fn s42(event: &Event) -> Outcome<State> {
         match event {
             Event::E43 => Transition(State::s43()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -408,7 +408,7 @@ impl BenchComplex {
     async fn s43(event: &Event) -> Outcome<State> {
         match event {
             Event::E44 => Transition(State::s44()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -416,7 +416,7 @@ impl BenchComplex {
     async fn s44(event: &Event) -> Outcome<State> {
         match event {
             Event::E45 => Transition(State::s45()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -424,7 +424,7 @@ impl BenchComplex {
     async fn s45(event: &Event) -> Outcome<State> {
         match event {
             Event::E46 => Transition(State::s46()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -432,7 +432,7 @@ impl BenchComplex {
     async fn s46(event: &Event) -> Outcome<State> {
         match event {
             Event::E47 => Transition(State::s47()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -440,7 +440,7 @@ impl BenchComplex {
     async fn s47(event: &Event) -> Outcome<State> {
         match event {
             Event::E48 => Transition(State::s48()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -448,7 +448,7 @@ impl BenchComplex {
     async fn s48(event: &Event) -> Outcome<State> {
         match event {
             Event::E49 => Transition(State::s49()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -456,7 +456,7 @@ impl BenchComplex {
     async fn s49(event: &Event) -> Outcome<State> {
         match event {
             Event::E50 => Transition(State::s50()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -464,7 +464,7 @@ impl BenchComplex {
     async fn s50(event: &Event) -> Outcome<State> {
         match event {
             Event::E51 => Transition(State::idle()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 }

--- a/examples/macro/barrier/src/main.rs
+++ b/examples/macro/barrier/src/main.rs
@@ -38,13 +38,13 @@ impl Foo {
     fn waiting_for_initialization(a: &bool, b: &bool, c: &bool) -> Outcome<State> {
         match (a, b, c) {
             (true, true, true) => Transition(State::initialized()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
     #[state]
     fn initialized() -> Outcome<State> {
-        Handled
+        Handled(())
     }
 }
 

--- a/examples/macro/bench_complex/src/main.rs
+++ b/examples/macro/bench_complex/src/main.rs
@@ -64,7 +64,7 @@ impl BenchComplex {
     fn idle(event: &Event) -> Outcome<State> {
         match event {
             Event::E1 => Transition(State::s2()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -72,7 +72,7 @@ impl BenchComplex {
     fn s1(event: &Event) -> Outcome<State> {
         match event {
             Event::E2 => Transition(State::s2()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -80,7 +80,7 @@ impl BenchComplex {
     fn s2(event: &Event) -> Outcome<State> {
         match event {
             Event::E3 => Transition(State::s3()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -88,7 +88,7 @@ impl BenchComplex {
     fn s3(event: &Event) -> Outcome<State> {
         match event {
             Event::E4 => Transition(State::s4()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -96,7 +96,7 @@ impl BenchComplex {
     fn s4(event: &Event) -> Outcome<State> {
         match event {
             Event::E5 => Transition(State::s5()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -104,7 +104,7 @@ impl BenchComplex {
     fn s5(event: &Event) -> Outcome<State> {
         match event {
             Event::E6 => Transition(State::s6()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -112,7 +112,7 @@ impl BenchComplex {
     fn s6(event: &Event) -> Outcome<State> {
         match event {
             Event::E7 => Transition(State::s7()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -120,7 +120,7 @@ impl BenchComplex {
     fn s7(event: &Event) -> Outcome<State> {
         match event {
             Event::E8 => Transition(State::s8()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -128,7 +128,7 @@ impl BenchComplex {
     fn s8(event: &Event) -> Outcome<State> {
         match event {
             Event::E9 => Transition(State::s9()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -136,7 +136,7 @@ impl BenchComplex {
     fn s9(event: &Event) -> Outcome<State> {
         match event {
             Event::E10 => Transition(State::s10()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -144,7 +144,7 @@ impl BenchComplex {
     fn s10(event: &Event) -> Outcome<State> {
         match event {
             Event::E11 => Transition(State::s11()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -152,7 +152,7 @@ impl BenchComplex {
     fn s11(event: &Event) -> Outcome<State> {
         match event {
             Event::E12 => Transition(State::s12()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -160,7 +160,7 @@ impl BenchComplex {
     fn s12(event: &Event) -> Outcome<State> {
         match event {
             Event::E13 => Transition(State::s13()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -168,7 +168,7 @@ impl BenchComplex {
     fn s13(event: &Event) -> Outcome<State> {
         match event {
             Event::E14 => Transition(State::s14()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -176,7 +176,7 @@ impl BenchComplex {
     fn s14(event: &Event) -> Outcome<State> {
         match event {
             Event::E15 => Transition(State::s15()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -184,7 +184,7 @@ impl BenchComplex {
     fn s15(event: &Event) -> Outcome<State> {
         match event {
             Event::E16 => Transition(State::s16()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -192,7 +192,7 @@ impl BenchComplex {
     fn s16(event: &Event) -> Outcome<State> {
         match event {
             Event::E17 => Transition(State::s17()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -200,7 +200,7 @@ impl BenchComplex {
     fn s17(event: &Event) -> Outcome<State> {
         match event {
             Event::E18 => Transition(State::s18()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -208,7 +208,7 @@ impl BenchComplex {
     fn s18(event: &Event) -> Outcome<State> {
         match event {
             Event::E19 => Transition(State::s19()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -216,7 +216,7 @@ impl BenchComplex {
     fn s19(event: &Event) -> Outcome<State> {
         match event {
             Event::E20 => Transition(State::s20()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -224,7 +224,7 @@ impl BenchComplex {
     fn s20(event: &Event) -> Outcome<State> {
         match event {
             Event::E21 => Transition(State::s21()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -232,7 +232,7 @@ impl BenchComplex {
     fn s21(event: &Event) -> Outcome<State> {
         match event {
             Event::E22 => Transition(State::s22()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -240,7 +240,7 @@ impl BenchComplex {
     fn s22(event: &Event) -> Outcome<State> {
         match event {
             Event::E23 => Transition(State::s23()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -248,7 +248,7 @@ impl BenchComplex {
     fn s23(event: &Event) -> Outcome<State> {
         match event {
             Event::E24 => Transition(State::s24()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -256,7 +256,7 @@ impl BenchComplex {
     fn s24(event: &Event) -> Outcome<State> {
         match event {
             Event::E25 => Transition(State::s25()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -264,7 +264,7 @@ impl BenchComplex {
     fn s25(event: &Event) -> Outcome<State> {
         match event {
             Event::E26 => Transition(State::s26()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -272,7 +272,7 @@ impl BenchComplex {
     fn s26(event: &Event) -> Outcome<State> {
         match event {
             Event::E27 => Transition(State::s27()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -280,7 +280,7 @@ impl BenchComplex {
     fn s27(event: &Event) -> Outcome<State> {
         match event {
             Event::E28 => Transition(State::s28()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -288,7 +288,7 @@ impl BenchComplex {
     fn s28(event: &Event) -> Outcome<State> {
         match event {
             Event::E29 => Transition(State::s29()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -296,7 +296,7 @@ impl BenchComplex {
     fn s29(event: &Event) -> Outcome<State> {
         match event {
             Event::E30 => Transition(State::s30()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -304,7 +304,7 @@ impl BenchComplex {
     fn s30(event: &Event) -> Outcome<State> {
         match event {
             Event::E31 => Transition(State::s31()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -312,7 +312,7 @@ impl BenchComplex {
     fn s31(event: &Event) -> Outcome<State> {
         match event {
             Event::E32 => Transition(State::s32()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -320,7 +320,7 @@ impl BenchComplex {
     fn s32(event: &Event) -> Outcome<State> {
         match event {
             Event::E33 => Transition(State::s33()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -328,7 +328,7 @@ impl BenchComplex {
     fn s33(event: &Event) -> Outcome<State> {
         match event {
             Event::E34 => Transition(State::s34()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -336,7 +336,7 @@ impl BenchComplex {
     fn s34(event: &Event) -> Outcome<State> {
         match event {
             Event::E35 => Transition(State::s35()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -344,7 +344,7 @@ impl BenchComplex {
     fn s35(event: &Event) -> Outcome<State> {
         match event {
             Event::E36 => Transition(State::s36()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -352,7 +352,7 @@ impl BenchComplex {
     fn s36(event: &Event) -> Outcome<State> {
         match event {
             Event::E37 => Transition(State::s37()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -360,7 +360,7 @@ impl BenchComplex {
     fn s37(event: &Event) -> Outcome<State> {
         match event {
             Event::E38 => Transition(State::s38()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -368,7 +368,7 @@ impl BenchComplex {
     fn s38(event: &Event) -> Outcome<State> {
         match event {
             Event::E39 => Transition(State::s39()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -376,7 +376,7 @@ impl BenchComplex {
     fn s39(event: &Event) -> Outcome<State> {
         match event {
             Event::E40 => Transition(State::s40()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -384,7 +384,7 @@ impl BenchComplex {
     fn s40(event: &Event) -> Outcome<State> {
         match event {
             Event::E41 => Transition(State::s41()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -392,7 +392,7 @@ impl BenchComplex {
     fn s41(event: &Event) -> Outcome<State> {
         match event {
             Event::E42 => Transition(State::s42()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -400,7 +400,7 @@ impl BenchComplex {
     fn s42(event: &Event) -> Outcome<State> {
         match event {
             Event::E43 => Transition(State::s43()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -408,7 +408,7 @@ impl BenchComplex {
     fn s43(event: &Event) -> Outcome<State> {
         match event {
             Event::E44 => Transition(State::s44()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -416,7 +416,7 @@ impl BenchComplex {
     fn s44(event: &Event) -> Outcome<State> {
         match event {
             Event::E45 => Transition(State::s45()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -424,7 +424,7 @@ impl BenchComplex {
     fn s45(event: &Event) -> Outcome<State> {
         match event {
             Event::E46 => Transition(State::s46()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -432,7 +432,7 @@ impl BenchComplex {
     fn s46(event: &Event) -> Outcome<State> {
         match event {
             Event::E47 => Transition(State::s47()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -440,7 +440,7 @@ impl BenchComplex {
     fn s47(event: &Event) -> Outcome<State> {
         match event {
             Event::E48 => Transition(State::s48()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -448,7 +448,7 @@ impl BenchComplex {
     fn s48(event: &Event) -> Outcome<State> {
         match event {
             Event::E49 => Transition(State::s49()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -456,7 +456,7 @@ impl BenchComplex {
     fn s49(event: &Event) -> Outcome<State> {
         match event {
             Event::E50 => Transition(State::s50()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 
@@ -464,7 +464,7 @@ impl BenchComplex {
     fn s50(event: &Event) -> Outcome<State> {
         match event {
             Event::E51 => Transition(State::idle()),
-            _ => Handled,
+            _ => Handled(()),
         }
     }
 }

--- a/examples/macro/calculator/src/state.rs
+++ b/examples/macro/calculator/src/state.rs
@@ -122,7 +122,7 @@ impl Calculator {
     #[state(superstate = "operand1")]
     fn zero1(&mut self, event: &Event) -> Outcome<State> {
         match event {
-            Event::Digit { digit: 0 } => Handled,
+            Event::Digit { digit: 0 } => Handled(()),
 
             Event::Digit { digit } => {
                 self.display.push_str(&digit.to_string());
@@ -152,7 +152,7 @@ impl Calculator {
 
             Event::Digit { digit } => {
                 self.display.push_str(&digit.to_string());
-                Handled
+                Handled(())
             }
 
             _ => Super,
@@ -166,11 +166,11 @@ impl Calculator {
     #[state(superstate = "operand1")]
     fn frac1(&mut self, event: &Event) -> Outcome<State> {
         match event {
-            Event::Point => Handled,
+            Event::Point => Handled(()),
 
             Event::Digit { digit } => {
                 self.display.push_str(&digit.to_string());
-                Handled
+                Handled(())
             }
 
             _ => Super,
@@ -207,7 +207,7 @@ impl Calculator {
                 Transition(State::frac1())
             }
 
-            Event::Operator { .. } => Handled,
+            Event::Operator { .. } => Handled(()),
 
             Event::Ac => {
                 self.display.clear();
@@ -233,7 +233,7 @@ impl Calculator {
 
             Event::Ce => {
                 self.display.clear();
-                Handled
+                Handled(())
             }
 
             Event::Operator { operator } => {
@@ -285,7 +285,7 @@ impl Calculator {
                 Transition(State::negated2(*operand1, *operator))
             }
 
-            Event::Operator { .. } => Handled,
+            Event::Operator { .. } => Handled(()),
 
             _ => Super,
         }
@@ -298,7 +298,7 @@ impl Calculator {
     #[state(superstate = "operand2")]
     fn zero2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
-            Event::Digit { digit: 0 } => Handled,
+            Event::Digit { digit: 0 } => Handled(()),
 
             Event::Digit { digit } => {
                 self.display = digit.to_string();
@@ -328,7 +328,7 @@ impl Calculator {
 
             Event::Digit { digit } => {
                 self.display.push_str(&digit.to_string());
-                Handled
+                Handled(())
             }
 
             _ => Super,
@@ -345,11 +345,11 @@ impl Calculator {
     )]
     fn frac2(&mut self, event: &Event) -> Outcome<State> {
         match event {
-            Event::Point => Handled,
+            Event::Point => Handled(()),
 
             Event::Digit { digit } => {
                 self.display.push_str(&digit.to_string());
-                Handled
+                Handled(())
             }
 
             _ => Super,
@@ -422,7 +422,7 @@ impl Calculator {
                 Transition(State::frac2(*operand1, *operator))
             }
 
-            Event::Operator { .. } => Handled,
+            Event::Operator { .. } => Handled(()),
 
             Event::Ac => {
                 self.display.clear();

--- a/examples/no_macro/basic/src/main.rs
+++ b/examples/no_macro/basic/src/main.rs
@@ -29,6 +29,8 @@ impl IntoStateMachine for Blinky {
 
     type Context<'ctx> = ();
 
+    type Response = ();
+
     /// The initial state of the state machine.
     fn initial() -> Self::State {
         State::Off

--- a/examples/no_macro/basic/src/main.rs
+++ b/examples/no_macro/basic/src/main.rs
@@ -36,6 +36,10 @@ impl IntoStateMachine for Blinky {
         State::Off
     }
 
+    fn default_response() -> Self::Response {
+        ()
+    }
+
     /// This method is called on every transition of the state machine.
     fn after_transition(&mut self, source: &Self::State, target: &Self::State, _context: &mut ()) {
         println!("transitioned from {source:?} to {target:?}");

--- a/examples/no_macro/bench/src/main.rs
+++ b/examples/no_macro/bench/src/main.rs
@@ -48,6 +48,8 @@ impl IntoStateMachine for CdPlayer {
 
     type Context<'ctx> = ();
 
+    type Response = ();
+
     /// The initial state of the state machine.
     fn initial() -> Self::State {
         State::Empty

--- a/examples/no_macro/bench/src/main.rs
+++ b/examples/no_macro/bench/src/main.rs
@@ -54,6 +54,10 @@ impl IntoStateMachine for CdPlayer {
     fn initial() -> Self::State {
         State::Empty
     }
+
+    fn default_response() -> Self::Response {
+        ()
+    }
 }
 
 impl blocking::State<CdPlayer> for State {

--- a/examples/no_macro/blinky/src/main.rs
+++ b/examples/no_macro/blinky/src/main.rs
@@ -46,6 +46,10 @@ impl IntoStateMachine for Blinky {
     fn initial() -> State {
         State::LedOn
     }
+
+    fn default_response() -> Self::Response {
+        ()
+    }
 }
 
 // Implement the `statig::State` trait for the state enum.

--- a/examples/no_macro/blinky/src/main.rs
+++ b/examples/no_macro/blinky/src/main.rs
@@ -40,6 +40,8 @@ impl IntoStateMachine for Blinky {
 
     type Context<'ctx> = ();
 
+    type Response = ();
+
     /// The initial state of the state machine.
     fn initial() -> State {
         State::LedOn

--- a/examples/no_macro/calculator/src/state.rs
+++ b/examples/no_macro/calculator/src/state.rs
@@ -71,6 +71,10 @@ impl blocking::IntoStateMachine for Calculator {
     fn initial() -> Self::State {
         State::Begin
     }
+
+    fn default_response() -> Self::Response {
+        ()
+    }
 }
 
 impl blocking::State<Calculator> for State {

--- a/examples/no_macro/calculator/src/state.rs
+++ b/examples/no_macro/calculator/src/state.rs
@@ -66,6 +66,8 @@ impl blocking::IntoStateMachine for Calculator {
 
     type Context<'ctx> = ();
 
+    type Response = ();
+
     fn initial() -> Self::State {
         State::Begin
     }
@@ -241,7 +243,7 @@ impl Calculator {
     /// - [`Event::Point`] => [`frac1`](Self::frac1)
     fn zero1(&mut self, event: &Event) -> Outcome<State> {
         match event {
-            Event::Digit { digit: 0 } => Handled,
+            Event::Digit { digit: 0 } => Handled(()),
 
             Event::Digit { digit } => {
                 self.display.push_str(&digit.to_string());
@@ -270,7 +272,7 @@ impl Calculator {
 
             Event::Digit { digit } => {
                 self.display.push_str(&digit.to_string());
-                Handled
+                Handled(())
             }
 
             _ => Super,
@@ -283,11 +285,11 @@ impl Calculator {
     /// - [`Event::Digit`] => `(handled)`
     fn frac1(&mut self, event: &Event) -> Outcome<State> {
         match event {
-            Event::Point => Handled,
+            Event::Point => Handled(()),
 
             Event::Digit { digit } => {
                 self.display.push_str(&digit.to_string());
-                Handled
+                Handled(())
             }
 
             _ => Super,
@@ -323,7 +325,7 @@ impl Calculator {
                 Transition(State::Frac1)
             }
 
-            Event::Operator { .. } => Handled,
+            Event::Operator { .. } => Handled(()),
 
             Event::Ac => {
                 self.display.clear();
@@ -348,7 +350,7 @@ impl Calculator {
 
             Event::Ce => {
                 self.display.clear();
-                Handled
+                Handled(())
             }
 
             Event::Operator { operator } => {
@@ -409,7 +411,7 @@ impl Calculator {
                 })
             }
 
-            Event::Operator { .. } => Handled,
+            Event::Operator { .. } => Handled(()),
 
             _ => Super,
         }
@@ -421,7 +423,7 @@ impl Calculator {
     /// - [`Event::Point`] => [`frac2`](Self::frac2)
     fn zero2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
-            Event::Digit { digit: 0 } => Handled,
+            Event::Digit { digit: 0 } => Handled(()),
 
             Event::Digit { digit } => {
                 self.display = digit.to_string();
@@ -459,7 +461,7 @@ impl Calculator {
 
             Event::Digit { digit } => {
                 self.display.push_str(&digit.to_string());
-                Handled
+                Handled(())
             }
 
             _ => Super,
@@ -473,11 +475,11 @@ impl Calculator {
     #[allow(unused)]
     fn frac2(&mut self, operand1: &f32, operator: &Operator, event: &Event) -> Outcome<State> {
         match event {
-            Event::Point => Handled,
+            Event::Point => Handled(()),
 
             Event::Digit { digit } => {
                 self.display.push_str(&digit.to_string());
-                Handled
+                Handled(())
             }
 
             _ => Super,
@@ -563,7 +565,7 @@ impl Calculator {
                 })
             }
 
-            Event::Operator { .. } => Handled,
+            Event::Operator { .. } => Handled(()),
 
             Event::Ac => {
                 self.display.clear();

--- a/examples/no_macro/history/src/main.rs
+++ b/examples/no_macro/history/src/main.rs
@@ -36,6 +36,8 @@ impl IntoStateMachine for Dishwasher {
 
     type Context<'ctx> = ();
 
+    type Response = ();
+
     fn initial() -> Self::State {
         State::Idle
     }

--- a/examples/no_macro/history/src/main.rs
+++ b/examples/no_macro/history/src/main.rs
@@ -42,6 +42,10 @@ impl IntoStateMachine for Dishwasher {
         State::Idle
     }
 
+    fn default_response() -> Self::Response {
+        ()
+    }
+
     // On every transition we update the previous state, so we can
     // transition back to it.
     fn after_transition(&mut self, source: &Self::State, _target: &Self::State, _context: &mut ()) {

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -326,7 +326,7 @@ fn codegen_state_impl_state(ir: &Ir) -> ItemImpl {
                     shared_storage: &mut #shared_storage_type,
                     #event_ident: &<#shared_storage_type as statig::awaitable::IntoStateMachine>::Event<'_>,
                     #context_ident: &mut <#shared_storage_type as statig::awaitable::IntoStateMachine>::Context<'_>
-                ) -> impl core::future::Future<Output = statig::Outcome<Self>> {
+                ) -> impl core::future::Future<Output = statig::Outcome<Self, <#shared_storage_type as statig::awaitable::IntoStateMachine>::Response>> {
                     async move {
                         match self {
                             #(#call_handler_arms),*
@@ -501,7 +501,7 @@ fn codegen_superstate_impl_superstate(ir: &Ir) -> ItemImpl {
                         shared_storage: &mut #shared_storage_type,
                         #event_ident: &<#shared_storage_type as statig::awaitable::IntoStateMachine>::Event<'_>,
                         #context_ident: &mut <#shared_storage_type as statig::awaitable::IntoStateMachine>::Context<'_>
-                    ) -> impl core::future::Future<Output = statig::Outcome<<#shared_storage_type as statig::awaitable::IntoStateMachine>::State>> {
+                    ) -> impl core::future::Future<Output = statig::Outcome<<#shared_storage_type as statig::awaitable::IntoStateMachine>::State, <#shared_storage_type as statig::awaitable::IntoStateMachine>::Response>> {
                         async move {
                             match self {
                                 #(#call_handler_arms),*

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -44,6 +44,7 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
         &ir.state_machine.shared_storage_generics.split_for_impl();
     let event_type = &ir.state_machine.event_type;
     let context_type = &ir.state_machine.context_type;
+    let response_type = &ir.state_machine.response_type;
     let state_ident = &ir.state_machine.state_ident.as_ident();
     let (_, state_generics, _) = &ir.state_machine.state_generics.split_for_impl();
     let superstate_ident = &ir.state_machine.superstate_ident;
@@ -176,6 +177,7 @@ fn codegen_state_machine_impl(ir: &Ir) -> ItemImpl {
         {
             type Event<#event_lifetime> = #event_type;
             type Context<#context_lifetime> = #context_type;
+            type Response = #response_type;
             type State = #state_ident #state_generics;
             type Superstate<#superstate_lifetime> = #superstate_ident #superstate_generics ;
 
@@ -280,7 +282,7 @@ fn codegen_state_impl_state(ir: &Ir) -> ItemImpl {
                         shared_storage: &mut #shared_storage_type,
                         #event_ident: &<#shared_storage_type as statig::blocking::IntoStateMachine>::Event<'_>,
                         #context_ident: &mut <#shared_storage_type as statig::blocking::IntoStateMachine>::Context<'_>
-                    ) -> statig::Outcome<Self> where Self: Sized {
+                    ) -> statig::Outcome<Self, <#shared_storage_type as statig::blocking::IntoStateMachine>::Response> where Self: Sized {
                         match self {
                             #(#call_handler_arms),*
                         }
@@ -454,7 +456,7 @@ fn codegen_superstate_impl_superstate(ir: &Ir) -> ItemImpl {
                         shared_storage: &mut #shared_storage_type,
                         #event_ident: &<#shared_storage_type as statig::blocking::IntoStateMachine>::Event<'_>,
                         #context_ident: &mut <#shared_storage_type as statig::blocking::IntoStateMachine>::Context<'_>
-                    ) -> statig::Outcome<<#shared_storage_type as statig::blocking::IntoStateMachine>::State> where Self: Sized {
+                    ) -> statig::Outcome<<#shared_storage_type as statig::blocking::IntoStateMachine>::State, <#shared_storage_type as statig::blocking::IntoStateMachine>::Response> where Self: Sized {
                         match self {
                             #(#call_handler_arms),*
                         }

--- a/macro/src/lower.rs
+++ b/macro/src/lower.rs
@@ -76,6 +76,8 @@ pub struct StateMachine {
     pub context_ident: Ident,
     /// Whether the state machine is sync (blocking) or async (awaitable).
     pub mode: Mode,
+    /// Response type returned when events are handled.
+    pub response_type: Type,
 }
 
 /// Information regarding a state.
@@ -470,6 +472,7 @@ pub fn lower(model: &Model) -> Ir {
         event_ident,
         context_ident,
         mode,
+        response_type: model.state_machine.response_type.clone(),
     };
 
     Ir {
@@ -794,6 +797,7 @@ fn create_analyze_state_machine() -> analyze::StateMachine {
         visibility: parse_quote!(pub),
         event_ident: parse_quote!(input),
         context_ident: parse_quote!(context),
+        response_type: parse_quote!(()),
     }
 }
 
@@ -826,6 +830,7 @@ fn create_lower_state_machine() -> StateMachine {
         event_ident: parse_quote!(input),
         context_ident: parse_quote!(context),
         mode: Mode::Blocking,
+        response_type: parse_quote!(()),
     }
 }
 

--- a/macro/src/lower.rs
+++ b/macro/src/lower.rs
@@ -78,6 +78,10 @@ pub struct StateMachine {
     pub mode: Mode,
     /// Response type returned when events are handled.
     pub response_type: Type,
+    /// Error type returned when events are handled.
+    pub error_type: Type,
+    /// Whether the state machine uses Result-based responses.
+    pub uses_result_responses: bool,
 }
 
 /// Information regarding a state.
@@ -473,6 +477,8 @@ pub fn lower(model: &Model) -> Ir {
         context_ident,
         mode,
         response_type: model.state_machine.response_type.clone(),
+        error_type: model.state_machine.error_type.clone(),
+        uses_result_responses: model.state_machine.uses_result_responses,
     };
 
     Ir {
@@ -798,6 +804,8 @@ fn create_analyze_state_machine() -> analyze::StateMachine {
         event_ident: parse_quote!(input),
         context_ident: parse_quote!(context),
         response_type: parse_quote!(()),
+        error_type: parse_quote!(()),
+        uses_result_responses: false,
     }
 }
 
@@ -831,6 +839,8 @@ fn create_lower_state_machine() -> StateMachine {
         context_ident: parse_quote!(context),
         mode: Mode::Blocking,
         response_type: parse_quote!(()),
+        error_type: parse_quote!(()),
+        uses_result_responses: false,
     }
 }
 

--- a/statig/src/awaitable/inner.rs
+++ b/statig/src/awaitable/inner.rs
@@ -33,11 +33,11 @@ where
             .handle(&mut self.shared_storage, event, context)
             .await;
         match outcome {
-            Outcome::Super => M::Response::default(),
+            Outcome::Super => M::default_response(),
             Outcome::Handled(response) => response,
             Outcome::Transition(state) => {
                 self.transition(state, context).await;
-                M::Response::default()
+                M::default_response()
             }
         }
     }

--- a/statig/src/awaitable/inner.rs
+++ b/statig/src/awaitable/inner.rs
@@ -27,15 +27,18 @@ where
         &mut self,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) {
+    ) -> M::Response {
         let outcome = self
             .state
             .handle(&mut self.shared_storage, event, context)
             .await;
         match outcome {
-            Outcome::Super => {}
-            Outcome::Handled(_) => {}
-            Outcome::Transition(state) => self.transition(state, context).await,
+            Outcome::Super => M::Response::default(),
+            Outcome::Handled(response) => response,
+            Outcome::Transition(state) => {
+                self.transition(state, context).await;
+                M::Response::default()
+            }
         }
     }
 

--- a/statig/src/awaitable/inner.rs
+++ b/statig/src/awaitable/inner.rs
@@ -34,7 +34,7 @@ where
             .await;
         match outcome {
             Outcome::Super => {}
-            Outcome::Handled => {}
+            Outcome::Handled(_) => {}
             Outcome::Transition(state) => self.transition(state, context).await,
         }
     }

--- a/statig/src/awaitable/into_state_machine.rs
+++ b/statig/src/awaitable/into_state_machine.rs
@@ -13,6 +13,9 @@ where
     /// External context that can be passed in.
     type Context<'ctx>;
 
+    /// Response type returned when events are handled.
+    type Response: Default;
+
     /// Enumeration of the various states.
     type State;
 

--- a/statig/src/awaitable/into_state_machine.rs
+++ b/statig/src/awaitable/into_state_machine.rs
@@ -14,7 +14,10 @@ where
     type Context<'ctx>;
 
     /// Response type returned when events are handled.
-    type Response: Default;
+    type Response;
+
+    /// Generate a default response for transitions and super outcomes.
+    fn default_response() -> Self::Response;
 
     /// Enumeration of the various states.
     type State;

--- a/statig/src/awaitable/state.rs
+++ b/statig/src/awaitable/state.rs
@@ -155,7 +155,7 @@ where
                                 Some(superstate_of_superstate) => {
                                     superstate = superstate_of_superstate
                                 }
-                                None => break Outcome::Handled(M::Response::default()),
+                                None => break Outcome::Handled(M::default_response()),
                             },
                             Outcome::Transition(state) => break Outcome::Transition(state),
                         }

--- a/statig/src/awaitable/state_machine.rs
+++ b/statig/src/awaitable/state_machine.rs
@@ -134,7 +134,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let state_machine = Blinky::default().state_machine();
@@ -163,7 +163,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let mut state_machine = Blinky::default().state_machine();
@@ -195,7 +195,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let mut state_machine = Blinky::default().state_machine();
@@ -404,7 +404,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// # executor::block_on(async {
@@ -437,7 +437,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// # executor::block_on(async {
@@ -472,7 +472,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// # executor::block_on(async {
@@ -609,7 +609,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// # executor::block_on(async {
@@ -645,7 +645,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// # executor::block_on(async {
@@ -682,7 +682,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -707,7 +707,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -737,7 +737,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     async fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     async fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();

--- a/statig/src/awaitable/state_machine.rs
+++ b/statig/src/awaitable/state_machine.rs
@@ -350,35 +350,35 @@ where
     for<'sub> M::Superstate<'sub>: Superstate<M>,
 {
     /// Handle the given event.
-    pub async fn handle(&mut self, event: &M::Event<'_>)
+    pub async fn handle(&mut self, event: &M::Event<'_>) -> M::Response
     where
         for<'ctx> M: IntoStateMachine<Context<'ctx> = ()>,
     {
-        self.handle_with_context(event, &mut ()).await;
+        self.handle_with_context(event, &mut ()).await
     }
 
     /// Handle the given event.
-    pub async fn handle_with_context(&mut self, event: &M::Event<'_>, context: &mut M::Context<'_>)
+    pub async fn handle_with_context(&mut self, event: &M::Event<'_>, context: &mut M::Context<'_>) -> M::Response
     where
         M: IntoStateMachine,
     {
-        self.inner.handle_with_context(event, context).await;
+        self.inner.handle_with_context(event, context).await
     }
 
     /// This is the same as `handle(())` in the case `Event` is of type `()`.
-    pub async fn step(&mut self)
+    pub async fn step(&mut self) -> M::Response
     where
         for<'evt, 'ctx> M: IntoStateMachine<Event<'evt> = (), Context<'ctx> = ()>,
     {
-        self.handle(&()).await;
+        self.handle(&()).await
     }
 
     /// This is the same as `handle(())` in the case `Event` is of type `()`.
-    pub async fn step_with_context(&mut self, context: &mut M::Context<'_>)
+    pub async fn step_with_context(&mut self, context: &mut M::Context<'_>) -> M::Response
     where
         for<'evt> M: IntoStateMachine<Event<'evt> = ()>,
     {
-        self.handle_with_context(&(), context).await;
+        self.handle_with_context(&(), context).await
     }
 
     /// Get an immutable reference to the current state of the state machine.

--- a/statig/src/awaitable/state_machine.rs
+++ b/statig/src/awaitable/state_machine.rs
@@ -77,11 +77,11 @@ where
 
     /// Handle an event. If the state machine is still uninitialized, it will be initialized
     /// before handling the event.
-    pub async fn handle(&mut self, event: &M::Event<'_>)
+    pub async fn handle(&mut self, event: &M::Event<'_>) -> M::Response
     where
         for<'ctx> M: IntoStateMachine<Context<'ctx> = ()>,
     {
-        self.handle_with_context(event, &mut ()).await;
+        self.handle_with_context(event, &mut ()).await
     }
 
     /// Handle an event. If the state machine is still uninitialized, it will be initialized
@@ -90,26 +90,26 @@ where
         &mut self,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) {
+    ) -> M::Response {
         if !self.initialized {
             self.inner.init_with_context(context).await;
             self.initialized = true;
         }
-        self.inner.handle_with_context(event, context).await;
+        self.inner.handle_with_context(event, context).await
     }
 
-    pub async fn step(&mut self)
+    pub async fn step(&mut self) -> M::Response
     where
         for<'evt, 'ctx> M: IntoStateMachine<Event<'evt> = (), Context<'ctx> = ()>,
     {
-        self.handle_with_context(&(), &mut ()).await;
+        self.handle_with_context(&(), &mut ()).await
     }
 
-    pub async fn step_with_context(&mut self, context: &mut M::Context<'_>)
+    pub async fn step_with_context(&mut self, context: &mut M::Context<'_>) -> M::Response
     where
         for<'evt> M: IntoStateMachine<Event<'evt> = ()>,
     {
-        self.handle_with_context(&(), context).await;
+        self.handle_with_context(&(), context).await
     }
 
     /// Get the current state.

--- a/statig/src/awaitable/superstate.rs
+++ b/statig/src/awaitable/superstate.rs
@@ -110,7 +110,7 @@ where
         _: &M::Event<'_>,
         _: &mut M::Context<'_>,
     ) -> impl Future<Output = Outcome<M::State, M::Response>> {
-        core::future::ready(Outcome::Handled(M::Response::default()))
+        core::future::ready(Outcome::Handled(M::default_response()))
     }
 
     fn call_entry_action(&mut self, _: &mut M, _: &mut M::Context<'_>) -> impl Future<Output = ()> {

--- a/statig/src/awaitable/superstate.rs
+++ b/statig/src/awaitable/superstate.rs
@@ -15,7 +15,7 @@ where
         shared_storage: &mut M,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) -> impl Future<Output = Outcome<M::State>>;
+    ) -> impl Future<Output = Outcome<M::State, M::Response>>;
 
     #[allow(unused)]
     /// Call the entry action for the current superstate.
@@ -109,8 +109,8 @@ where
         _: &mut M,
         _: &M::Event<'_>,
         _: &mut M::Context<'_>,
-    ) -> impl Future<Output = Outcome<M::State>> {
-        core::future::ready(Outcome::Handled)
+    ) -> impl Future<Output = Outcome<M::State, M::Response>> {
+        core::future::ready(Outcome::Handled(M::Response::default()))
     }
 
     fn call_entry_action(&mut self, _: &mut M, _: &mut M::Context<'_>) -> impl Future<Output = ()> {

--- a/statig/src/blocking/inner.rs
+++ b/statig/src/blocking/inner.rs
@@ -28,12 +28,15 @@ where
         &mut self,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) {
+    ) -> M::Response {
         let outcome = self.state.handle(&mut self.shared_storage, event, context);
         match outcome {
-            Outcome::Super => {}
-            Outcome::Handled => {}
-            Outcome::Transition(state) => self.transition(state, context),
+            Outcome::Super => M::Response::default(),
+            Outcome::Handled(response) => response,
+            Outcome::Transition(state) => {
+                self.transition(state, context);
+                M::Response::default()
+            }
         }
     }
 

--- a/statig/src/blocking/inner.rs
+++ b/statig/src/blocking/inner.rs
@@ -31,11 +31,11 @@ where
     ) -> M::Response {
         let outcome = self.state.handle(&mut self.shared_storage, event, context);
         match outcome {
-            Outcome::Super => M::Response::default(),
-            Outcome::Handled(response) => response,
+            Outcome::Super => M::default_response(),
+            Outcome::Handled(result) => result,
             Outcome::Transition(state) => {
                 self.transition(state, context);
-                M::Response::default()
+                M::default_response()
             }
         }
     }

--- a/statig/src/blocking/into_state_machine.rs
+++ b/statig/src/blocking/into_state_machine.rs
@@ -12,7 +12,10 @@ where
     type Context<'ctx>;
 
     /// Response type returned when events are handled.
-    type Response: Default;
+    type Response;
+
+    /// Generate a default response for transitions and super outcomes.
+    fn default_response() -> Self::Response;
 
     /// Enumeration of the various states.
     type State;

--- a/statig/src/blocking/into_state_machine.rs
+++ b/statig/src/blocking/into_state_machine.rs
@@ -11,6 +11,9 @@ where
     /// External context that can be passed in.
     type Context<'ctx>;
 
+    /// Response type returned when events are handled.
+    type Response: Default;
+
     /// Enumeration of the various states.
     type State;
 

--- a/statig/src/blocking/state.rs
+++ b/statig/src/blocking/state.rs
@@ -13,7 +13,7 @@ where
         shared_storage: &mut M,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) -> Outcome<Self>;
+    ) -> Outcome<Self, M::Response>;
 
     #[allow(unused)]
     /// Call the entry action for the current state.
@@ -89,7 +89,7 @@ where
         shared_storage: &mut M,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) -> Outcome<Self>
+    ) -> Outcome<Self, M::Response>
     where
         Self: Sized,
     {
@@ -110,7 +110,7 @@ where
         );
 
         match outcome {
-            Outcome::Handled => Outcome::Handled,
+            Outcome::Handled(response) => Outcome::Handled(response),
             Outcome::Super => match self.superstate() {
                 Some(mut superstate) => {
                     M::before_dispatch(

--- a/statig/src/blocking/state_machine.rs
+++ b/statig/src/blocking/state_machine.rs
@@ -75,21 +75,21 @@ where
 
     /// Handle an event. If the state machine is still uninitialized, it will be initialized
     /// before handling the event.
-    pub fn handle(&mut self, event: &M::Event<'_>)
+    pub fn handle(&mut self, event: &M::Event<'_>) -> M::Response
     where
         for<'ctx> M: IntoStateMachine<Context<'ctx> = ()>,
     {
-        self.handle_with_context(event, &mut ());
+        self.handle_with_context(event, &mut ())
     }
 
     /// Handle an event. If the state machine is still uninitialized, it will be initialized
     /// before handling the event.
-    pub fn handle_with_context(&mut self, event: &M::Event<'_>, context: &mut M::Context<'_>) {
+    pub fn handle_with_context(&mut self, event: &M::Event<'_>, context: &mut M::Context<'_>) -> M::Response {
         if !self.initialized {
             self.inner.init_with_context(context);
             self.initialized = true;
         }
-        self.inner.handle_with_context(event, context);
+        self.inner.handle_with_context(event, context)
     }
 
     pub fn step(&mut self)
@@ -128,7 +128,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let state_machine = Blinky::default().state_machine();
@@ -157,7 +157,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let mut state_machine = Blinky::default().state_machine();
@@ -189,7 +189,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let mut state_machine = Blinky::default().state_machine();
@@ -400,7 +400,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -430,7 +430,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// # let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -462,7 +462,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -595,7 +595,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -629,7 +629,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -664,7 +664,7 @@ where
     /// # )]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -689,7 +689,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();
@@ -719,7 +719,7 @@ where
     /// # #[state_machine(initial = "State::on()")]
     /// # impl Blinky {
     /// #     #[state]
-    /// #     fn on(event: &Event) -> Outcome<State> { Handled }
+    /// #     fn on(event: &Event) -> Outcome<State> { Handled(()) }
     /// # }
     /// #
     /// let mut uninitialized_state_machine = Blinky::default().uninitialized_state_machine();

--- a/statig/src/blocking/state_machine.rs
+++ b/statig/src/blocking/state_machine.rs
@@ -343,39 +343,39 @@ where
     M::State: State<M>,
 {
     /// Handle the given event.
-    pub fn handle(&mut self, event: &M::Event<'_>)
+    pub fn handle(&mut self, event: &M::Event<'_>) -> M::Response
     where
         for<'ctx> M: IntoStateMachine<Context<'ctx> = ()>,
         for<'sub> M::Superstate<'sub>: Superstate<M>,
     {
-        self.handle_with_context(event, &mut ());
+        self.handle_with_context(event, &mut ())
     }
 
     /// Handle the given event.
-    pub fn handle_with_context(&mut self, event: &M::Event<'_>, context: &mut M::Context<'_>)
+    pub fn handle_with_context(&mut self, event: &M::Event<'_>, context: &mut M::Context<'_>) -> M::Response
     where
         M: IntoStateMachine,
         for<'sub> M::Superstate<'sub>: Superstate<M>,
     {
-        self.inner.handle_with_context(event, context);
+        self.inner.handle_with_context(event, context)
     }
 
     /// This is the same as `handle(())` in the case `Event` is of type `()`.
-    pub fn step(&mut self)
+    pub fn step(&mut self) -> M::Response
     where
         for<'evt, 'ctx> M: IntoStateMachine<Event<'evt> = (), Context<'ctx> = ()>,
         for<'sub> M::Superstate<'sub>: Superstate<M>,
     {
-        self.handle(&());
+        self.handle(&())
     }
 
     /// This is the same as `handle(())` in the case `Event` is of type `()`.
-    pub fn step_with_context(&mut self, context: &mut M::Context<'_>)
+    pub fn step_with_context(&mut self, context: &mut M::Context<'_>) -> M::Response
     where
         for<'evt> M: IntoStateMachine<Event<'evt> = ()>,
         for<'sub> M::Superstate<'sub>: Superstate<M>,
     {
-        self.handle_with_context(&(), context);
+        self.handle_with_context(&(), context)
     }
 
     /// Get an immutable reference to the current state of the state machine.

--- a/statig/src/blocking/state_machine.rs
+++ b/statig/src/blocking/state_machine.rs
@@ -92,18 +92,18 @@ where
         self.inner.handle_with_context(event, context)
     }
 
-    pub fn step(&mut self)
+    pub fn step(&mut self) -> M::Response
     where
         for<'evt, 'ctx> M: IntoStateMachine<Event<'evt> = (), Context<'ctx> = ()>,
     {
-        self.handle_with_context(&(), &mut ());
+        self.handle_with_context(&(), &mut ())
     }
 
-    pub fn step_with_context(&mut self, context: &mut M::Context<'_>)
+    pub fn step_with_context(&mut self, context: &mut M::Context<'_>) -> M::Response
     where
         for<'evt> M: IntoStateMachine<Event<'evt> = ()>,
     {
-        self.handle_with_context(&(), context);
+        self.handle_with_context(&(), context)
     }
 
     /// Get the current state.

--- a/statig/src/blocking/superstate.rs
+++ b/statig/src/blocking/superstate.rs
@@ -170,7 +170,7 @@ where
         _: &M::Event<'_>,
         _: &mut M::Context<'_>,
     ) -> Outcome<M::State, M::Response> {
-        Outcome::Handled(M::Response::default())
+        Outcome::Handled(M::default_response())
     }
 
     fn call_entry_action(&mut self, _: &mut M, _: &mut M::Context<'_>) {}

--- a/statig/src/blocking/superstate.rs
+++ b/statig/src/blocking/superstate.rs
@@ -14,7 +14,7 @@ where
         shared_storage: &mut M,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) -> Outcome<M::State>;
+    ) -> Outcome<M::State, M::Response>;
 
     #[allow(unused)]
     /// Call the entry action for the current superstate.
@@ -92,14 +92,14 @@ where
         shared_storage: &mut M,
         event: &M::Event<'_>,
         context: &mut M::Context<'_>,
-    ) -> Outcome<M::State>
+    ) -> Outcome<M::State, M::Response>
     where
         Self: Sized,
     {
         let outcome = self.call_handler(shared_storage, event, context);
 
         match outcome {
-            Outcome::Handled => Outcome::Handled,
+            Outcome::Handled(response) => Outcome::Handled(response),
             Outcome::Super => match self.superstate() {
                 Some(mut superstate) => {
                     M::before_dispatch(
@@ -169,8 +169,8 @@ where
         _: &mut M,
         _: &M::Event<'_>,
         _: &mut M::Context<'_>,
-    ) -> Outcome<M::State> {
-        Outcome::Handled
+    ) -> Outcome<M::State, M::Response> {
+        Outcome::Handled(M::Response::default())
     }
 
     fn call_entry_action(&mut self, _: &mut M, _: &mut M::Context<'_>) {}

--- a/statig/src/outcome.rs
+++ b/statig/src/outcome.rs
@@ -1,9 +1,9 @@
 use core::fmt::Debug;
 
 /// Outcome returned by event handlers in a state machine.
-pub enum Outcome<S> {
+pub enum Outcome<S, R = ()> {
     /// Consider the event handled.
-    Handled,
+    Handled(R),
     /// Defer the event to the superstate.
     Super,
     /// Transition to the given state.
@@ -12,15 +12,16 @@ pub enum Outcome<S> {
 
 /// Type alias that will be removed in some future release. Use `Outcome` instead.
 #[deprecated(since = "0.4", note = "`Response` has been renamed to `Outcome`")]
-pub type Response<S> = Outcome<S>;
+pub type Response<S, R = ()> = Outcome<S, R>;
 
-impl<S> PartialEq for Outcome<S>
+impl<S, R> PartialEq for Outcome<S, R>
 where
     S: PartialEq,
+    R: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Handled, Self::Handled) => true,
+            (Self::Handled(r1), Self::Handled(r2)) => r1 == r2,
             (Self::Super, Self::Super) => true,
             (Self::Transition(s), Self::Transition(o)) => s == o,
             _ => false,
@@ -28,15 +29,19 @@ where
     }
 }
 
-impl<S> Eq for Outcome<S> where S: Eq {}
+impl<S, R> Eq for Outcome<S, R> where S: Eq, R: Eq {}
 
-impl<S> Debug for Outcome<S>
+impl<S, R> Debug for Outcome<S, R>
 where
     S: Debug,
+    R: Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Handled => f.debug_tuple("Handled").finish(),
+            Self::Handled(response) => f
+                .debug_tuple("Handled")
+                .field(response as &dyn Debug)
+                .finish(),
             Self::Super => f.debug_tuple("Super").finish(),
             Self::Transition(state) => f
                 .debug_tuple("Transition")

--- a/statig/tests/async_transition.rs
+++ b/statig/tests/async_transition.rs
@@ -63,6 +63,10 @@ mod tests {
         fn initial() -> Self::State {
             State::S11
         }
+
+        fn default_response() -> Self::Response {
+            ()
+        }
     }
 
     impl awaitable::State<Foo> for State {

--- a/statig/tests/async_transition.rs
+++ b/statig/tests/async_transition.rs
@@ -58,6 +58,8 @@ mod tests {
 
         type Context<'ctx> = ();
 
+        type Response = ();
+
         fn initial() -> Self::State {
             State::S11
         }
@@ -283,7 +285,7 @@ mod tests {
         /// s
         #[allow(unused)]
         async fn s(&mut self, event: &Event) -> Outcome {
-            Handled
+            Handled(())
         }
 
         async fn enter_s(&mut self) {

--- a/statig/tests/async_transition_macro.rs
+++ b/statig/tests/async_transition_macro.rs
@@ -180,7 +180,7 @@ mod tests {
         #[allow(unused)]
         #[superstate(entry_action = "enter_s", exit_action = "exit_s")]
         pub async fn s(&mut self, event: &Event) -> Outcome {
-            Handled
+            Handled(())
         }
 
         #[action]

--- a/statig/tests/config_macro.rs
+++ b/statig/tests/config_macro.rs
@@ -29,14 +29,14 @@ mod tests {
             #[state(superstate = "foo")]
             fn bar(my_event: &Event, my_context: &mut Context) -> Outcome<MyState> {
                 match my_event {
-                    Event::A => Handled,
+                    Event::A => Handled(()),
                 }
             }
 
             #[superstate]
             fn foo(my_event: &Event, my_context: &mut Context) -> Outcome<MyState> {
                 match my_event {
-                    Event::A => Handled,
+                    Event::A => Handled(()),
                 }
             }
         }

--- a/statig/tests/default.rs
+++ b/statig/tests/default.rs
@@ -13,7 +13,7 @@ mod tests {
             #[default] local: &mut usize,
             #[default = "100"] local_2: &mut usize,
         ) -> Outcome<State> {
-            Handled
+            Handled(())
         }
     }
 

--- a/statig/tests/external_context.rs
+++ b/statig/tests/external_context.rs
@@ -20,7 +20,7 @@ mod tests {
             match event {
                 Event::ButtonPressed => {
                     *context.0 = context.0.saturating_add(1);
-                    Handled
+                    Handled(())
                 }
                 Event::TimerElapsed => Transition(State::down()),
             }
@@ -31,7 +31,7 @@ mod tests {
             match event {
                 Event::ButtonPressed => {
                     *context.0 = context.0.saturating_sub(1);
-                    Handled
+                    Handled(())
                 }
                 Event::TimerElapsed => Transition(State::up()),
             }

--- a/statig/tests/generics.rs
+++ b/statig/tests/generics.rs
@@ -26,17 +26,17 @@ mod tests {
     {
         #[state]
         fn a() -> Outcome<State<T, B, SIZE>> {
-            Handled
+            Handled(())
         }
 
         #[state]
         fn b(array: &mut [T; SIZE]) -> Outcome<State<T, B, SIZE>> {
-            Handled
+            Handled(())
         }
 
         #[state]
         fn c(deref: &B) -> Outcome<State<T, B, SIZE>> {
-            Handled
+            Handled(())
         }
     }
 }

--- a/statig/tests/response_test.rs
+++ b/statig/tests/response_test.rs
@@ -1,0 +1,77 @@
+#[cfg(test)]
+mod tests {
+    #![allow(unused)]
+
+    use statig::blocking::*;
+
+    pub enum Event {
+        Transition,
+        TestSuperAck,
+        TestSuperNak
+    }
+
+    #[derive(Debug, PartialEq)]
+    pub enum Response {
+        ResponseOk,
+        ResponseNak,
+    }
+
+    impl core::default::Default for Response {
+        fn default() -> Self {
+            Response::ResponseOk
+        }
+    }
+
+    pub struct Foo;
+
+    #[state_machine(initial = "State::bar()")]
+    impl Foo {
+        #[state(superstate = "baz")]
+        fn bar(event: &Event) -> Outcome<State, Response> {
+            match event {
+                Event::Transition => Transition(State::qux()),
+                Event::TestSuperAck => Super,
+                Event::TestSuperNak => Super,
+            }
+        }
+
+        #[superstate]
+        fn baz(event: &Event) -> Outcome<State, Response> {
+            match event {
+                Event::TestSuperAck => Handled(Response::ResponseOk),
+                Event::TestSuperNak => Handled(Response::ResponseNak),
+                _ => Handled(Response::ResponseOk),
+            }
+        }
+
+        #[state]
+        fn qux(event: &Event) -> Outcome<State, Response> {
+            Handled(Response::ResponseOk)
+        }
+
+    }
+
+    #[test]
+    fn transition_test() {
+        let mut foo = Foo.state_machine();
+        
+        let response = foo.handle(&Event::Transition);
+        assert_eq!(response, Response::ResponseOk);   
+    }
+
+    #[test]
+    fn super_ack_test() {
+        let mut foo = Foo.state_machine();
+        
+        let response = foo.handle(&Event::TestSuperAck);
+        assert_eq!(response, Response::ResponseOk);   
+    }
+
+    #[test]
+    fn super_nak_test() {
+        let mut foo = Foo.state_machine();
+
+        let response = foo.handle(&Event::TestSuperNak);
+        assert_eq!(response, Response::ResponseNak);
+    }
+}

--- a/statig/tests/response_test_async.rs
+++ b/statig/tests/response_test_async.rs
@@ -1,0 +1,79 @@
+#[cfg(test)]
+#[cfg(feature = "async")]
+
+mod tests {
+    #![allow(unused)]
+
+    use statig::awaitable::*;
+
+    pub enum Event {
+        Transition,
+        TestSuperAck,
+        TestSuperNak
+    }
+
+    #[derive(Debug, PartialEq)]
+    pub enum Response {
+        ResponseOk,
+        ResponseNak,
+    }
+
+    impl core::default::Default for Response {
+        fn default() -> Self {
+            Response::ResponseOk
+        }
+    }
+
+    pub struct Foo;
+
+    #[state_machine(initial = "State::bar()")]
+    impl Foo {
+        #[state(superstate = "baz")]
+        async fn bar(event: &Event) -> Outcome<State, Response> {
+            match event {
+                Event::Transition => Transition(State::qux()),
+                Event::TestSuperAck => Super,
+                Event::TestSuperNak => Super,
+            }
+        }
+
+        #[superstate]
+        async fn baz(event: &Event) -> Outcome<State, Response> {
+            match event {
+                Event::TestSuperAck => Handled(Response::ResponseOk),
+                Event::TestSuperNak => Handled(Response::ResponseNak),
+                _ => Handled(Response::ResponseOk),
+            }
+        }
+
+        #[state]
+        async fn qux(event: &Event) -> Outcome<State, Response> {
+            Handled(Response::ResponseOk)
+        }
+
+    }
+
+    #[test]
+    fn transition_test() {
+        let mut foo = Foo.state_machine();
+
+        let response = futures::executor::block_on(async { foo.handle(&Event::Transition).await });
+        assert_eq!(response, Response::ResponseOk);
+    }
+
+    #[test]
+    fn super_ack_test() {
+        let mut foo = Foo.state_machine();
+
+        let response = futures::executor::block_on(async { foo.handle(&Event::TestSuperAck).await });
+        assert_eq!(response, Response::ResponseOk);
+    }
+
+    #[test]
+    fn super_nak_test() {
+        let mut foo = Foo.state_machine();
+
+        let response = futures::executor::block_on(async { foo.handle(&Event::TestSuperNak).await });
+        assert_eq!(response, Response::ResponseNak);
+    }
+}

--- a/statig/tests/state_local_storage.rs
+++ b/statig/tests/state_local_storage.rs
@@ -29,6 +29,10 @@ mod tests {
         fn initial() -> Self::State {
             Superstate::playing()
         }
+        
+        fn default_response() -> Self::Response {
+            Self::Response::default()
+        }
     }
 
     impl Default for State {

--- a/statig/tests/state_local_storage.rs
+++ b/statig/tests/state_local_storage.rs
@@ -23,6 +23,8 @@ mod tests {
 
         type Context<'ctx> = ();
 
+        type Response = ();
+
         /// The initial state of the state machine.
         fn initial() -> Self::State {
             Superstate::playing()
@@ -52,7 +54,7 @@ mod tests {
         }
 
         fn playing(&mut self, led: &mut bool) -> Outcome<State> {
-            Handled
+            Handled(())
         }
     }
 

--- a/statig/tests/state_local_storage_macro.rs
+++ b/statig/tests/state_local_storage_macro.rs
@@ -31,7 +31,7 @@ mod tests {
 
         #[superstate(initial = "State::on(false, 23)")]
         fn playing(&mut self, led: &mut bool) -> Outcome<State> {
-            Handled
+            Handled(())
         }
     }
 

--- a/statig/tests/transition.rs
+++ b/statig/tests/transition.rs
@@ -55,6 +55,8 @@ mod tests {
 
         type Context<'ctx> = ();
 
+        type Response = ();
+
         fn initial() -> Self::State {
             State::S11
         }
@@ -255,7 +257,7 @@ mod tests {
         /// s
         #[allow(unused)]
         pub fn s(&mut self, event: &Event) -> Outcome {
-            Handled
+            Handled(())
         }
 
         fn enter_s(&mut self) {

--- a/statig/tests/transition.rs
+++ b/statig/tests/transition.rs
@@ -60,6 +60,10 @@ mod tests {
         fn initial() -> Self::State {
             State::S11
         }
+
+        fn default_response() -> Self::Response {
+            ()
+        }
     }
 
     impl blocking::State<Foo> for State {

--- a/statig/tests/transition_macro.rs
+++ b/statig/tests/transition_macro.rs
@@ -179,7 +179,7 @@ mod tests {
         #[allow(unused)]
         #[superstate(entry_action = "enter_s", exit_action = "exit_s")]
         pub fn s(&mut self, event: &Event) -> Outcome {
-            Handled
+            Handled(())
         }
 
         #[action]


### PR DESCRIPTION
Hi,

A few weeks ago I ran into the same issue as AbstractiveNord: I needed a way to return data from handled events. I require acknowledgments for state change requests, sometimes also actual data from the states themselves.

I've implemented a solution that works well for my use case. However, this is a breaking change, so I don't expect this to be merged at all. I'm sharing it in case it's helpful to others.

I've also added a usage example in response_test.