### PR TITLE
chore: Right align line numbers in ui-test

### DIFF
--- a/statig/Cargo.toml
+++ b/statig/Cargo.toml
@@ -22,7 +22,7 @@ futures = { version = "0.3.26" }
 serde_json = "1.0.91"
 serde = { version = "1.0.152", features = ["derive"] }
 unit-enum = { git = "https://github.com/mdeloof/unit-enum.git" }
-trybuild = "1.0.90"
+trybuild = "1.0.108"
 
 [features]
 default = ["macro"]

--- a/statig/tests/ui/custom_state_derive_error.stderr
+++ b/statig/tests/ui/custom_state_derive_error.stderr
@@ -7,7 +7,7 @@ error: Can not use `custom` with derives
 error[E0599]: the method `state_machine` exists for struct `Blinky`, but its trait bounds were not satisfied
   --> tests/ui/custom_state_derive_error.rs:51:47
    |
-6  | pub struct Blinky {}
+ 6 | pub struct Blinky {}
    | ----------------- method `state_machine` not found for this struct because it doesn't satisfy `Blinky: statig::awaitable::IntoStateMachineExt`, `Blinky: statig::awaitable::IntoStateMachine`, `Blinky: statig::blocking::IntoStateMachineExt` or `Blinky: statig::blocking::IntoStateMachine`
 ...
 51 |     let mut state_machine = Blinky::default().state_machine();


### PR DESCRIPTION
Problem: rust-lang/rust@aa9767290e46c9c73fa1fd3abb52277b4d07cfae right
aligned line numbers & this change was released in Rust 1.90. This
causes our trybuild driven ui-tests to fail because the line number
differs.

Solution: Fix the line numbering in the test's stderr file & bump our
min trybuild dependency to v1.0.108 because that is the first version
that recognizes right aligned line numbers.

Testing: Ran `cargo +1.90 test` and saw that it worked. Also tested
specifying `trybuild = "=1.0.n" and saw that n=108 was the lowest
working version.

Ref: https://github.com/rust-lang/rust/pull/144609
Ref: https://github.com/dtolnay/trybuild/pull/308
Ref: https://github.com/dtolnay/trybuild/issues/315
