### PR TITLE
Relax trait bounds on State and Superstate associated types  

### DIFF
--- a/statig/src/awaitable/inner.rs
+++ b/statig/src/awaitable/inner.rs
@@ -1,5 +1,6 @@
-use crate::awaitable::{IntoStateMachine, State, StateExt, Superstate};
+use crate::awaitable::{IntoStateMachine, StateExt};
 use crate::Outcome;
+use core::fmt::Debug;
 
 /// Private internal representation of a state machine that is used for the public types.
 pub(crate) struct Inner<M>
@@ -13,8 +14,6 @@ where
 impl<M> Inner<M>
 where
     M: IntoStateMachine,
-    M::State: State<M> + 'static,
-    for<'sub> M::Superstate<'sub>: Superstate<M>,
 {
     pub(crate) async fn init_with_context(&mut self, context: &mut M::Context<'_>) {
         let enter_levels = self.state.depth();
@@ -91,6 +90,19 @@ where
     M: IntoStateMachine + Eq,
     M::State: Eq,
 {
+}
+
+impl<M> Debug for Inner<M>
+where
+    M: IntoStateMachine + Debug,
+    M::State: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Inner")
+            .field("shared_storage", &self.shared_storage)
+            .field("state", &self.state)
+            .finish()
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/statig/src/awaitable/into_state_machine.rs
+++ b/statig/src/awaitable/into_state_machine.rs
@@ -14,10 +14,10 @@ where
     type Context<'ctx>;
 
     /// Enumeration of the various states.
-    type State;
+    type State: crate::awaitable::State<Self>;
 
     /// Enumeration of the various superstates.
-    type Superstate<'sub>
+    type Superstate<'sub>: crate::awaitable::Superstate<Self>
     where
         Self::State: 'sub;
 

--- a/statig/src/awaitable/state.rs
+++ b/statig/src/awaitable/state.rs
@@ -9,7 +9,6 @@ pub trait State<M>
 where
     Self: Sized,
     M: IntoStateMachine<State = Self>,
-    for<'b> M::Superstate<'b>: Superstate<M>,
 {
     /// Call the handler for the current state and let it handle the given event.
     fn call_handler(
@@ -49,7 +48,6 @@ where
 pub trait StateExt<M>: State<M>
 where
     M: IntoStateMachine<State = Self>,
-    for<'b> M::Superstate<'b>: Superstate<M>,
 {
     /// Check if two states are the same.
     fn same_state(lhs: &Self, rhs: &Self) -> bool {
@@ -236,6 +234,5 @@ impl<T, M> StateExt<M> for T
 where
     Self: State<M>,
     M: IntoStateMachine<State = T>,
-    for<'b> M::Superstate<'b>: Superstate<M>,
 {
 }

--- a/statig/src/awaitable/state_machine.rs
+++ b/statig/src/awaitable/state_machine.rs
@@ -1,12 +1,9 @@
 use core::fmt::Debug;
 
-use crate::awaitable::{Inner, IntoStateMachine, State, Superstate};
+use crate::awaitable::{Inner, IntoStateMachine};
 
 /// A state machine where the shared storage is of type `Self`.
 pub trait IntoStateMachineExt: IntoStateMachine
-where
-    for<'sub> Self::Superstate<'sub>: Superstate<Self>,
-    Self::State: State<Self>,
 {
     /// Create a state machine that will be lazily initialized.
     fn state_machine(self) -> StateMachine<Self>
@@ -36,9 +33,7 @@ where
 
 impl<T> IntoStateMachineExt for T
 where
-    Self: IntoStateMachine,
-    for<'sub> Self::Superstate<'sub>: Superstate<Self>,
-    Self::State: State<Self>,
+    Self: IntoStateMachine
 {
 }
 
@@ -54,8 +49,6 @@ where
 impl<M> StateMachine<M>
 where
     M: IntoStateMachine,
-    M::State: State<M> + 'static,
-    for<'sub> M::Superstate<'sub>: Superstate<M>,
 {
     /// Explicitly initialize the state machine. If the state machine is already initialized
     /// this is a no-op.
@@ -289,6 +282,19 @@ where
     }
 }
 
+impl<M> Debug for StateMachine<M>
+where
+    M: IntoStateMachine + Debug,
+    M::State: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StateMachine")
+            .field("inner", &self.inner)
+            .field("initialized", &self.initialized)
+            .finish()
+    }
+}
+
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<M> serde::Serialize for StateMachine<M>
@@ -346,8 +352,6 @@ where
 impl<M> InitializedStateMachine<M>
 where
     M: IntoStateMachine,
-    M::State: State<M> + 'static,
-    for<'sub> M::Superstate<'sub>: Superstate<M>,
 {
     /// Handle the given event.
     pub async fn handle(&mut self, event: &M::Event<'_>)
@@ -590,8 +594,6 @@ where
 impl<M> UninitializedStateMachine<M>
 where
     M: IntoStateMachine,
-    M::State: State<M> + 'static,
-    for<'sub> M::Superstate<'sub>: Superstate<M>,
 {
     /// Initialize the state machine by executing all entry actions towards
     /// the initial state.

--- a/statig/src/awaitable/superstate.rs
+++ b/statig/src/awaitable/superstate.rs
@@ -47,11 +47,9 @@ where
 }
 
 /// Extensions for `Superstate` trait.
-pub trait SuperstateExt<M>: Superstate<M>
+pub trait SuperstateExt<M>: Superstate<M> + Sized
 where
-    Self: Sized,
     M: IntoStateMachine,
-    for<'sub> M::Superstate<'sub>: Superstate<M>,
 {
     fn same_state(lhs: &M::Superstate<'_>, rhs: &M::Superstate<'_>) -> bool {
         use core::mem::{discriminant, transmute, Discriminant};
@@ -131,8 +129,7 @@ where
 
 impl<T, M> SuperstateExt<M> for T
 where
-    Self: Superstate<M>,
+    T: Superstate<M>,
     M: IntoStateMachine,
-    for<'sub> M::Superstate<'sub>: Superstate<M>,
 {
 }

--- a/statig/src/blocking/inner.rs
+++ b/statig/src/blocking/inner.rs
@@ -1,4 +1,5 @@
-use crate::blocking::{IntoStateMachine, State, StateExt, Superstate};
+use core::fmt::{Debug, Formatter};
+use crate::blocking::{IntoStateMachine, StateExt};
 use crate::Outcome;
 
 /// Private internal representation of a state machine that is used for the public types.
@@ -13,8 +14,6 @@ where
 impl<M> Inner<M>
 where
     M: IntoStateMachine,
-    M::State: State<M>,
-    for<'sub> M::Superstate<'sub>: Superstate<M>,
 {
     /// Initialize the state machine by executing all entry actions towards the initial state.
     pub(crate) fn init_with_context(&mut self, context: &mut M::Context<'_>) {
@@ -87,6 +86,15 @@ where
     M: IntoStateMachine + Eq,
     M::State: Eq,
 {
+}
+
+impl<M> Debug for Inner<M> where M: IntoStateMachine + Debug, M::State: Debug {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Inner")
+            .field("shared_storage", &self.shared_storage)
+            .field("state", &self.state)
+            .finish()
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/statig/src/blocking/into_state_machine.rs
+++ b/statig/src/blocking/into_state_machine.rs
@@ -12,10 +12,10 @@ where
     type Context<'ctx>;
 
     /// Enumeration of the various states.
-    type State;
+    type State: crate::blocking::State<Self>;
 
     /// Enumeration of the various superstates.
-    type Superstate<'sub>
+    type Superstate<'sub>: crate::blocking::Superstate<Self>
     where
         Self::State: 'sub;
 

--- a/statig/src/blocking/state.rs
+++ b/statig/src/blocking/state.rs
@@ -1,4 +1,4 @@
-use crate::blocking::{IntoStateMachine, Superstate, SuperstateExt};
+use crate::blocking::{IntoStateMachine, SuperstateExt};
 use crate::{Outcome, StateOrSuperstate};
 
 /// An enum that represents the leaf states of the state machine.
@@ -30,11 +30,9 @@ where
 }
 
 /// Extensions for `State` trait.
-pub trait StateExt<'a, M>: State<M>
+pub trait StateExt<M>: State<M>
 where
     M: IntoStateMachine<State = Self>,
-    M::State: 'a,
-    for<'b> M::Superstate<'b>: Superstate<M>,
 {
     /// Check if two states are the same.
     fn same_state(lhs: &Self, rhs: &Self) -> bool {
@@ -168,11 +166,9 @@ where
     }
 }
 
-impl<'a, T, M> StateExt<'a, M> for T
+impl<T, M> StateExt<M> for T
 where
     T: State<M>,
     M: IntoStateMachine<State = T>,
-    M::State: 'a,
-    for<'b> M::Superstate<'b>: Superstate<M>,
 {
 }

--- a/statig/src/blocking/state_machine.rs
+++ b/statig/src/blocking/state_machine.rs
@@ -1,11 +1,9 @@
 use core::fmt::Debug;
 
-use crate::blocking::{Inner, IntoStateMachine, State, Superstate};
+use crate::blocking::{Inner, IntoStateMachine};
 
 /// A state machine where the shared storage is of type `Self`.
 pub trait IntoStateMachineExt: IntoStateMachine
-where
-    Self::State: State<Self>,
 {
     /// Create a state machine that will be lazily initialized.
     fn state_machine(self) -> StateMachine<Self>
@@ -35,8 +33,7 @@ where
 
 impl<T> IntoStateMachineExt for T
 where
-    T: IntoStateMachine,
-    Self::State: State<Self>,
+    T: IntoStateMachine
 {
 }
 
@@ -52,8 +49,6 @@ where
 impl<M> StateMachine<M>
 where
     M: IntoStateMachine,
-    M::State: State<M>,
-    for<'sub> M::Superstate<'sub>: Superstate<M>,
 {
     /// Explicitly initialize the state machine. If the state machine is already initialized
     /// this is a no-op.
@@ -283,6 +278,19 @@ where
     }
 }
 
+impl<M> Debug for StateMachine<M>
+where
+    M: IntoStateMachine + Debug,
+    M::State: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StateMachine")
+            .field("inner", &self.inner)
+            .field("initialized", &self.initialized)
+            .finish()
+    }
+}
+
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<M> serde::Serialize for StateMachine<M>
@@ -340,13 +348,11 @@ where
 impl<M> InitializedStateMachine<M>
 where
     M: IntoStateMachine,
-    M::State: State<M>,
 {
     /// Handle the given event.
     pub fn handle(&mut self, event: &M::Event<'_>)
     where
         for<'ctx> M: IntoStateMachine<Context<'ctx> = ()>,
-        for<'sub> M::Superstate<'sub>: Superstate<M>,
     {
         self.handle_with_context(event, &mut ());
     }
@@ -355,7 +361,6 @@ where
     pub fn handle_with_context(&mut self, event: &M::Event<'_>, context: &mut M::Context<'_>)
     where
         M: IntoStateMachine,
-        for<'sub> M::Superstate<'sub>: Superstate<M>,
     {
         self.inner.handle_with_context(event, context);
     }
@@ -364,7 +369,6 @@ where
     pub fn step(&mut self)
     where
         for<'evt, 'ctx> M: IntoStateMachine<Event<'evt> = (), Context<'ctx> = ()>,
-        for<'sub> M::Superstate<'sub>: Superstate<M>,
     {
         self.handle(&());
     }
@@ -373,7 +377,6 @@ where
     pub fn step_with_context(&mut self, context: &mut M::Context<'_>)
     where
         for<'evt> M: IntoStateMachine<Event<'evt> = ()>,
-        for<'sub> M::Superstate<'sub>: Superstate<M>,
     {
         self.handle_with_context(&(), context);
     }
@@ -578,7 +581,6 @@ where
 impl<M> UninitializedStateMachine<M>
 where
     M: IntoStateMachine,
-    M::State: State<M>,
 {
     /// Initialize the state machine by executing all entry actions towards
     /// the initial state.
@@ -607,7 +609,6 @@ where
     pub fn init(self) -> InitializedStateMachine<M>
     where
         for<'ctx> M: IntoStateMachine<Context<'ctx> = ()>,
-        for<'sub> M::Superstate<'sub>: Superstate<M>,
     {
         let mut state_machine = InitializedStateMachine { inner: self.inner };
         state_machine.inner.init_with_context(&mut ());
@@ -639,8 +640,6 @@ where
     /// let initialized_state_machine = uninitialized_state_machine.init();
     /// ```
     pub fn init_with_context(self, context: &mut M::Context<'_>) -> InitializedStateMachine<M>
-    where
-        for<'sub> M::Superstate<'sub>: Superstate<M>,
     {
         let mut state_machine = InitializedStateMachine { inner: self.inner };
         state_machine.inner.init_with_context(context);

--- a/statig/src/blocking/superstate.rs
+++ b/statig/src/blocking/superstate.rs
@@ -34,12 +34,9 @@ where
 }
 
 /// Extensions for `Superstate` trait.
-pub trait SuperstateExt<'a, M>: Superstate<M>
+pub trait SuperstateExt<M>: Superstate<M> + Sized
 where
     M: IntoStateMachine,
-    Self: Sized,
-    M::State: 'a,
-    for<'b> M::Superstate<'b>: Superstate<M>,
 {
     fn same_state(lhs: &M::Superstate<'_>, rhs: &M::Superstate<'_>) -> bool {
         use core::mem::{discriminant, transmute, Discriminant};
@@ -185,11 +182,9 @@ where
     }
 }
 
-impl<'a, T, M> SuperstateExt<'a, M> for T
+impl<T, M> SuperstateExt<M> for T
 where
     T: Superstate<M>,
     M: IntoStateMachine,
-    M::State: 'a,
-    for<'b> M::Superstate<'b>: Superstate<M>,
 {
 }


### PR DESCRIPTION
## Motivation

When working with generic state machines, you have to specify a bunch of trait bounds:

```rust
fn handle_machine<M>(machine: &mut StateMachine<M>)
where
    M: IntoStateMachine,
    M::State: State<M>,
    for<'sub> M::Superstate<'sub>: Superstate<M>,
{
    // ...
}
```

These bounds are verbose and add significant friction when writing generic code. I realized they're not actually needed at the call sites—they should be enforced at the trait definition level instead.

## Solution

By moving the bounds for State and SuperState to the IntoStateMachine trait it makes working with a generic state machine much cleaner!

```rust
pub trait IntoStateMachine {
    type State: State<Self>;  // Bound moved here
    type Superstate<'sub>: Superstate<Self>  // Bound moved here
    where
        Self::State: 'sub;
    // ...
}
```

Now the same code requires only:

```rust
fn handle_machine<M: IntoStateMachine>(machine: &mut StateMachine<M>) {
    // ✨ Much cleaner!
}
```

## Changes
- Core traits: Bounds added to State and Superstate associated types in IntoStateMachine
- Implementation blocks: Removed redundant bounds from ~30+ locations across:
  - blocking: inner.rs, state.rs, state_machine.rs, superstate.rs
  - awaitable: inner.rs, state.rs, state_machine.rs, superstate.rs
- Cleanup: Removed unused imports and unnecessary lifetimes (StateExt<'a, M> → StateExt<M>)

## AI Disclosure
I did **not** use any AI at all for any code changes in this PR. It is completely hand written and tested by me. 

I **did** use AI to review my changes and assist me in writing this description.